### PR TITLE
Add SGD optimizers

### DIFF
--- a/orangecontrib/educational/optimizers/__init__.py
+++ b/orangecontrib/educational/optimizers/__init__.py
@@ -1,0 +1,1 @@
+from .sgd_optimizers import *

--- a/orangecontrib/educational/optimizers/sgd_optimizers.py
+++ b/orangecontrib/educational/optimizers/sgd_optimizers.py
@@ -1,0 +1,574 @@
+import numpy as np
+import copy
+
+__all__ = ['SGD', 'Momentum', 'NesterovMomentum', 'AdaGrad', 'RMSProp',
+           'AdaDelta', 'Adam', 'Adamax', 'create_opt']
+
+
+def create_opt(opt2copy, learning_rate=None):
+    opt = copy.copy(opt2copy)  # Shallow copy
+    if learning_rate:
+        opt.learning_rate = learning_rate
+    return opt
+
+
+class SGD:
+    """Stochastic Gradient Descent (SGD) updates
+
+    Generates update expressions of the form:
+
+    * ``param := param - learning_rate * gradient``
+
+    Args:
+        learning_rate: float, optional
+            The learning rate controlling the size of update steps
+
+    """
+
+    def __init__(self, learning_rate=1.0):
+        self.learning_rate = learning_rate
+        self.name = 'Stochastic Gradient Descent'
+
+    def update(self, grads, params, indices=None):
+        """SGD updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array, optional
+                Indices in params to update
+
+        """
+        if indices is None:
+            indices = np.arange(len(params))
+
+        params[indices] -= self.learning_rate * grads
+
+    def __str__(self):
+        return self.name
+
+
+class Momentum:
+    """Stochastic Gradient Descent (SGD) updates with momentum
+
+    Generates update expressions of the form:
+
+    * ``velocity := momentum * velocity - learning_rate * gradient``
+    * ``param := param + velocity``
+
+    Args:
+        learning_rate: float
+                The learning rate controlling the size of update steps
+        momentum: float, optional
+            The amount of momentum to apply. Higher momentum results in
+            smoothing over more update steps. Defaults to 0.9.
+
+    Notes:
+        Higher momentum also results in larger update steps. To counter that,
+        you can optionally scale your learning rate by `1 - momentum`.
+
+    See Also:
+        apply_momentum: Generic function applying momentum to updates
+        nesterov_momentum: Nesterov's variant of SGD with momentum
+
+    """
+
+    def __init__(self, learning_rate=1.0, momentum=0.9):
+        self.learning_rate = learning_rate
+        self.momentum = momentum
+        self.velocity = None
+        self.name = 'Momentum'
+
+    def update(self, grads, params, indices=None):
+        """Momentum updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array
+                Indices in params to update
+
+        """
+
+        if indices is None:
+            indices = np.arange(len(params))
+
+        if self.velocity is None:
+            self.velocity = np.zeros(params.shape)
+
+        self.velocity[indices] = \
+            self.momentum * self.velocity[indices] - self.learning_rate * grads
+        params[indices] += self.velocity[indices]
+
+    def __str__(self):
+        return self.name
+
+
+class NesterovMomentum:
+    """Stochastic Gradient Descent (SGD) updates with Nesterov momentum
+
+    Generates update expressions of the form:
+
+    * ``param_ahead := param + momentum * velocity``
+    * ``velocity := momentum * velocity - learning_rate * gradient_ahead``
+    * ``param := param + velocity``
+
+    In order to express the update to look as similar to vanilla SGD, this can
+    be written as:
+
+    * ``v_prev := velocity``
+    * ``velocity := momentum * velocity - learning_rate * gradient``
+    * ``param := -momentum * v_prev + (1 + momentum) * velocity``
+
+    Args:
+        learning_rate : float
+            The learning rate controlling the size of update steps
+        momentum: float, optional
+            The amount of momentum to apply. Higher momentum results in
+            smoothing over more update steps. Defaults to 0.9.
+
+    Notes:
+        Higher momentum also results in larger update steps. To counter that,
+        you can optionally scale your learning rate by `1 - momentum`.
+
+        The classic formulation of Nesterov momentum (or Nesterov accelerated
+        gradient) requires the gradient to be evaluated at the predicted next
+        position in parameter space. Here, we use the formulation described at
+        https://github.com/lisa-lab/pylearn2/pull/136#issuecomment-10381617,
+        which allows the gradient to be evaluated at the current parameters.
+
+    See Also:
+        apply_nesterov_momentum: Function applying momentum to updates
+
+    """
+
+    def __init__(self, learning_rate=1.0, momentum=0.9):
+        self.learning_rate = learning_rate
+        self.momentum = momentum
+        self.velocity = None
+        self.name = "Nesterov's Accelerated Momentum"
+
+    def update(self, grads, params, indices=None):
+        """NAG updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array, optional
+                Indices in params to update
+
+        Returns
+            updates: list of float
+                Variables updated with the gradients
+
+        """
+
+        if indices is None:
+            indices = np.arange(len(params))
+
+        if self.velocity is None:
+            self.velocity = np.zeros(params.shape)
+
+        v_prev = self.velocity[indices]
+        self.velocity[indices] = \
+            self.momentum * self.velocity[indices] - self.learning_rate * grads
+        params[indices] += -self.momentum * v_prev + \
+                           (1 + self.momentum) * self.velocity[indices]
+
+    def __str__(self):
+        return self.name
+
+
+class AdaGrad:
+    """AdaGrad updates
+
+    Scale learning rates by dividing with the square root of accumulated
+    squared gradients. See [1]_ for further description.
+
+    * ``param := param - learning_rate * gradient``
+
+    Args:
+        learning_rate : float or symbolic scalar
+            The learning rate controlling the size of update steps
+        epsilon: float or symbolic scalar
+            Small value added for numerical stability
+
+    Notes:
+        Using step size eta Adagrad calculates the learning rate for feature i
+        at time step t as:
+
+        .. math:: \\eta_{t,i} = \\frac{\\eta}
+           {\\sqrt{\\sum^t_{t^\\prime} g^2_{t^\\prime,i}+\\epsilon}} g_{t,i}
+
+        as such the learning rate is monotonically decreasing.
+
+        Epsilon is not included in the typical formula, see [2]_.
+
+    References:
+        .. [1] Duchi, J., Hazan, E., & Singer, Y. (2011):
+               Adaptive subgradient methods for online learning and stochastic
+               optimization. JMLR, 12:2121-2159.
+
+        .. [2] Chris Dyer:
+               Notes on AdaGrad. http://www.ark.cs.cmu.edu/cdyer/adagrad.pdf
+
+    """
+
+    def __init__(self, learning_rate=1.0, epsilon=1e-6):
+        self.learning_rate = learning_rate
+        self.epsilon = epsilon
+        self.accu = None
+        self.name = 'AdaGrad'
+
+    def update(self, grads, params, indices=None):
+        """AdaGrad updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array, optional
+                Indices in params to update
+
+        """
+
+        if indices is None:
+            indices = np.arange(len(params))
+
+        if self.accu is None:
+            self.accu = np.zeros(params.shape)
+
+        self.accu[indices] += grads ** 2
+        den = np.sqrt(self.accu[indices] + self.epsilon)
+        params[indices] -= self.learning_rate * grads/den
+
+    def __str__(self):
+        return self.name
+
+
+class RMSProp:
+    """RMSProp
+
+    Scale learning rates by dividing with the moving average of the root mean
+    squared (RMS) gradients. See [3]_ for further description.
+
+    Args:
+        learning_rate: float
+            The learning rate controlling the size of update steps
+        rho: float
+            Gradient moving average decay factor
+        epsilon: float
+            Small value added for numerical stability
+
+    Notes:
+        `rho` should be between 0 and 1. A value of `rho` close to 1 will decay
+        the moving average slowly and a value close to 0 will decay the moving
+        average fast.
+
+        Using the step size :math:`\\eta` and a decay factor :math:`\\rho` the
+        learning rate :math:`\\eta_t` is calculated as:
+
+        .. math::
+           r_t &= \\rho r_{t-1} + (1-\\rho)*g^2\\\\
+           \\eta_t &= \\frac{\\eta}{\\sqrt{r_t + \\epsilon}}
+
+    References:
+        .. [3] Tieleman, T. and Hinton, G. (2012):
+               Neural Networks for Machine Learning, Lecture 6.5 - rmsprop.
+               Coursera. http://www.youtube.com/watch?v=O3sxAc4hxZU
+               (formula @5:20)
+
+    """
+
+    def __init__(self, learning_rate=1.0, rho=0.9, epsilon=1e-6):
+        self.learning_rate = learning_rate
+        self.rho = rho
+        self.epsilon = epsilon
+        self.accu = None
+        self.name = 'RMSProp'
+
+    def update(self, grads, params, indices=None):
+        """RMSProp updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array, optional
+                Indices in params to update
+
+        """
+
+        if indices is None:
+            indices = np.arange(len(params))
+
+        if self.accu is None:
+            self.accu = np.zeros(params.shape)
+
+        self.accu[indices] = \
+            self.rho * self.accu[indices] + (1 - self.rho) * grads ** 2
+        params[indices] -= self.learning_rate * grads /\
+                           np.sqrt(self.accu[indices] + self.epsilon)
+
+    def __str__(self):
+        return self.name
+
+
+class AdaDelta:
+    """AdaDelta
+
+    Scale learning rates by a the ratio of accumulated gradients to accumulated
+    step sizes, see [4]_ and notes for further description.
+
+    Args:
+        learning_rate: float
+            The learning rate controlling the size of update steps
+        rho: float
+            Squared gradient moving average decay factor
+        epsilon: float
+            Small value added for numerical stability
+
+    Notes:
+        rho should be between 0 and 1. A value of rho close to 1 will decay the
+        moving average slowly and a value close to 0 will decay the moving
+        average fast.
+
+        rho = 0.95 and epsilon=1e-6 are suggested in the paper and reported to
+        work for multiple datasets (MNIST, speech).
+
+        In the paper, no learning rate is considered (so learning_rate=1.0).
+        Probably best to keep it at this value.
+        epsilon is important for the very first update (so the numerator does
+        not become 0).
+
+        Using the step size eta and a decay factor rho the learning rate is
+        calculated as:
+
+        .. math::
+           r_t &= \\rho r_{t-1} + (1-\\rho)*g^2\\\\
+           \\eta_t &= \\eta \\frac{\\sqrt{s_{t-1} + \\epsilon}}
+                                 {\sqrt{r_t + \epsilon}}\\\\
+           s_t &= \\rho s_{t-1} + (1-\\rho)*g^2
+
+    References:
+        .. [4] Zeiler, M. D. (2012):
+               ADADELTA: An Adaptive Learning Rate Method.
+               arXiv Preprint arXiv:1212.5701.
+    """
+
+    def __init__(self, learning_rate=1.0, rho=0.95, epsilon=1e-6):
+        self.learning_rate = learning_rate
+        self.rho = rho
+        self.epsilon = epsilon
+        self.accu = None
+        self.delta_accu = None
+        self.name = 'AdaDelta'
+
+    def update(self, grads, params, indices=None):
+        """AdaDelta updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array, optional
+                Indices in params to update
+
+        """
+
+        if indices is None:
+            indices = np.arange(len(params))
+
+        if self.accu is None or self.delta_accu is None:
+            self.accu = np.zeros(params.shape)
+            self.delta_accu = np.zeros(params.shape)
+
+        self.accu[indices] = self.rho * self.accu[indices] + \
+                             (1 - self.rho) * grads ** 2
+
+        # compute parameter update, using the 'old' delta_accu
+        update = grads * np.sqrt(self.delta_accu[indices] + self.epsilon) / \
+                 np.sqrt(self.accu[indices] + self.epsilon)
+        params[indices] -= self.learning_rate * update
+
+        # update delta_accu (as accu, but accumulating updates)
+        delta_accu_new = \
+            self.rho * self.delta_accu[indices] + (1 - self.rho) * update ** 2
+        self.delta_accu[indices] = delta_accu_new
+
+        return params
+
+    def __str__(self):
+        return self.name
+
+
+class Adam:
+    """Adam
+
+    Adam updates implemented as in [5]_.
+
+    Args:
+        learning_rate : float
+            The learning rate controlling the size of update steps
+        beta_1 : float
+            Exponential decay rate for the first moment estimates.
+        beta_2 : float
+            Exponential decay rate for the second moment estimates.
+        epsilon : float
+            Constant for numerical stability.
+
+    Notes:
+        The paper [5]_ includes an additional hyperparameter lambda. This is
+        only needed to prove convergence of the algorithm and has no practical
+        use, it is therefore omitted here.
+
+    References:
+        .. [5] Kingma, Diederik, and Jimmy Ba (2014):
+               Adam: A Method for Stochastic Optimization.
+               arXiv preprint arXiv:1412.6980.
+
+    """
+
+    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999,
+         epsilon=1e-8):
+        self.learning_rate = learning_rate
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.epsilon = epsilon
+
+        self.t_prev = 0
+        self.m_prev = None
+        self.v_prev = None
+        self.name = 'Adam'
+
+    def update(self, grads, params, indices=None):
+        """Adam updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array, optional
+                Indices of parameters ('params') to update. If None (default),
+                all parameters will be updated.
+
+        Returns
+            updates: list of float
+                Variables updated with the gradients
+
+        """
+
+        if indices is None:
+            indices = np.arange(len(params))
+
+        if self.m_prev is None or self.v_prev is None:
+            self.m_prev = np.zeros(params.shape)
+            self.v_prev = np.zeros(params.shape)
+
+        t = self.t_prev + 1
+
+        # To understand the coefficients plot this:
+        #     sqrt(1-0.999^x)*(1-0.9^x)
+        # or this:
+        #     (1-0.999^x)*(1-0.9^x)
+        # Computing bias-corrected first and second moment estimates to
+        # counteract the effect of vt and mt been biased towards zero
+        a_t = self.learning_rate * np.sqrt(1 - self.beta2 ** t) / \
+              (1 - self.beta1 ** t)
+
+        self.m_prev[indices] = self.beta1 * self.m_prev[indices] + \
+                               (1 - self.beta1) * grads
+        self.v_prev[indices] = self.beta2 * self.v_prev[indices] + \
+                               (1 - self.beta2) * grads ** 2
+        params[indices] -= a_t * self.m_prev[indices] / \
+                           (np.sqrt(self.v_prev[indices]) + self.epsilon)
+
+        self.t_prev = t
+
+    def __str__(self):
+        return self.name
+
+class Adamax:
+    """Adamax
+
+    Adamax updates implemented as in [6]_. This is a variant of of the Adam
+    algorithm based on the infinity norm.
+
+    Args:
+        learning_rate : float
+            The learning rate controlling the size of update steps
+        beta_1 : float
+            Exponential decay rate for the first moment estimates.
+        beta_2 : float
+            Exponential decay rate for the second moment estimates.
+        epsilon : float
+            Constant for numerical stability.
+
+    References:
+        .. [6] Kingma, Diederik, and Jimmy Ba (2014):
+               Adam: A Method for Stochastic Optimization.
+               arXiv preprint arXiv:1412.6980.
+
+    """
+
+    def __init__(self, learning_rate=0.001, beta1=0.9, beta2=0.999,
+         epsilon=1e-8):
+        self.learning_rate = learning_rate
+        self.beta1 = beta1
+        self.beta2 = beta2
+        self.epsilon = epsilon
+
+        self.t_prev = 0
+        self.m_prev = None
+        self.u_prev = None
+        self.name = 'Adamax'
+
+    def update(self, grads, params, indices=None):
+        """Adamax updates
+
+        Args:
+            grads: array
+                List of gradient expressions
+            params: array
+                The variables to generate update expressions for
+            indices: array, optional
+                Indices of parameters ('params') to update. If None (default),
+                all parameters will be updated.
+
+        Returns
+            updates: list of float
+                Variables updated with the gradients
+
+        """
+
+        if indices is None:
+            indices = np.arange(len(params))
+
+        if self.m_prev is None or self.u_prev is None:
+            self.m_prev = np.zeros(params.shape)
+            self.u_prev = np.zeros(params.shape)
+
+        t = self.t_prev + 1
+        a_t = self.learning_rate/(1 - self.beta1**t)
+
+        self.m_prev[indices] = self.beta1 * self.m_prev[indices] + \
+                               (1 - self.beta1) * grads
+        self.u_prev[indices] = np.maximum(self.beta2 * self.u_prev[indices],
+                                          np.abs(grads))
+        params[indices] -= a_t * self.m_prev[indices] / \
+                           (self.u_prev[indices] + self.epsilon)
+
+        self.t_prev = t
+
+    def __str__(self):
+        return self.name

--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -22,6 +22,7 @@ from orangecontrib.educational.widgets.utils.linear_regression import \
 from orangecontrib.educational.widgets.utils.logistic_regression \
     import LogisticRegression
 from orangecontrib.educational.widgets.utils.contour import Contour
+import orangecontrib.educational.optimizers as opt
 
 
 class Scatterplot(highcharts.Highchart):
@@ -166,6 +167,17 @@ class OWGradientDescent(OWWidget):
     auto_play_speed = settings.Setting(1)
     stochastic = settings.Setting(False)
 
+    # SGD optimizers
+    class _Optimizer:
+        SGD, MOMENTUM, NAG, ADAGRAD, RMSPROP, ADADELTA, ADAM, ADAMAX = range(8)
+        names = ['Vanilla SGD', 'Momentum', "Nesterov momentum", 'AdaGrad',
+                 'RMSprop', 'AdaDelta', 'Adam', 'Adamax']
+    opt_type = settings.Setting(_Optimizer.SGD)
+    momentum = settings.Setting(0.9)
+    rho = settings.Setting(0.9)
+    beta1 = settings.Setting(0.9)
+    beta2 = settings.Setting(0.999)
+
     # models
     x_var_model = None
     y_var_model = None
@@ -238,16 +250,56 @@ class OWGradientDescent(OWWidget):
         self.alpha_spin = gui.spin(
             widget=self.properties_box, master=self, callback=self.change_alpha,
             value="alpha", label="Learning rate: ",
-            minv=0.001, maxv=100, step=0.001, spinType=float, decimals=3,
+            minv=1e-5, maxv=1e5, step=0.001, spinType=float, decimals=3,
             alignment=Qt.AlignRight, controlWidth=80)
+        self.step_size_spin = gui.spin(
+            widget=self.properties_box, master=self, callback=self.change_step,
+            value="step_size", label="Num. samples: ",
+            minv=1, maxv=100, step=1, alignment=Qt.AlignRight, controlWidth=80)
         self.stochastic_checkbox = gui.checkBox(
             widget=self.properties_box, master=self,
             callback=self.change_stochastic, value="stochastic",
             label="Stochastic ")
-        self.step_size_spin = gui.spin(
-            widget=self.properties_box, master=self, callback=self.change_step,
-            value="step_size", label="Step size: ",
-            minv=1, maxv=100, step=1, alignment=Qt.AlignRight, controlWidth=80)
+
+        self.combobox_opt = gui.comboBox(
+            widget=self.properties_box, master=self, value="opt_type",
+            label="SGD optimizer: ", items=self._Optimizer.names,
+            orientation=Qt.Horizontal, addSpace=4, callback=self._opt_changed)
+
+        paramtip = "Controls the 'inertia' of the update.\nHigher momentum " \
+                   "results in smoothing over more update steps"
+        _m_comp = gui.doubleSpin(
+            widget=self.properties_box, master=self, value="momentum",
+            minv=1e-4, maxv=1e+4, step=1e-4, label="Momentum:", decimals=4,
+            alignment=Qt.AlignRight, controlWidth=90,
+            callback=self._opt_changed, tooltip=paramtip)
+
+        paramtip = "Decay rate of the gradient moving average"
+        _r_comp = gui.doubleSpin(
+            widget=self.properties_box, master=self, value="rho", minv=1e-4,
+            maxv=1e+4, step=1e-4, label="Rho:", decimals=4,
+            alignment=Qt.AlignRight, controlWidth=90,
+            callback=self._opt_changed, tooltip=paramtip)
+
+        paramtip = "Exponential decay rate for the 1st moment estimates " \
+                   "(the mean)"
+        _b1_comp = gui.doubleSpin(
+            widget=self.properties_box, master=self, value="beta1", minv=1e-5,
+            maxv=1e+5, step=1e-4, label="Beta 1:", decimals=5,
+            alignment=Qt.AlignRight, controlWidth=90,
+            callback=self._opt_changed, tooltip=paramtip)
+
+        paramtip = "Exponential decay rate for the 2nd moment estimates (the " \
+                   "uncentered variance)"
+        _b2_comp = gui.doubleSpin(
+            widget=self.properties_box, master=self, value="beta2", minv=1e-5,
+            maxv=1e+5, step=1e-4, label="Beta 2:", decimals=5,
+            alignment=Qt.AlignRight, controlWidth=90,
+            callback=self._opt_changed, tooltip=paramtip)
+
+        self._opt_params = [_m_comp, _r_comp, _b1_comp, _b2_comp]
+        self._show_right_optimizer()
+
         self.restart_button = gui.button(
             widget=self.properties_box, master=self,
             callback=self.restart, label="Restart")
@@ -296,6 +348,59 @@ class OWGradientDescent(OWWidget):
 
         self.step_size_lock()
         self.step_back_button_lock()
+
+    def _opt_changed(self):
+        self._show_right_optimizer()
+        self.select_optimizer()
+
+    def _show_right_optimizer(self):
+        enabled = [[False, False, False, False],  # SGD
+                   [True, False, False, False],  # Momentum
+                   [True, False, False, False],  # NAG
+                   [False, False, False, False],  # AdaGrad
+                   [False, True, False, False],  # RMSprop
+                   [False, True, False, False],  # AdaDelta
+                   [False, False, True, True],  # Adam
+                   [False, False, True, True],  # Adamax
+                ]
+
+        mask = [False, False, False, False]
+        self.combobox_opt.box.setVisible(self.stochastic)
+        if self.stochastic:
+            mask = enabled[self.opt_type]
+
+        # All hidden
+        for spin, enabled in zip(self._opt_params, mask):
+            [spin.box.hide, spin.box.show][enabled]()
+
+    def select_optimizer(self):
+        if self.learner is not None:
+            if self.opt_type == self._Optimizer.MOMENTUM:
+                self.learner.sgd_optimizer = opt.Momentum(
+                    momentum=self.momentum
+                )
+            elif self.opt_type == self._Optimizer.NAG:
+                self.learner.sgd_optimizer = opt.NesterovMomentum(
+                    momentum=self.momentum
+                )
+            elif self.opt_type == self._Optimizer.ADAGRAD:
+                self.learner.sgd_optimizer = opt.AdaGrad()
+
+            elif self.opt_type == self._Optimizer.RMSPROP:
+                self.learner.sgd_optimizer = opt.RMSProp(rho=self.rho)
+
+            elif self.opt_type == self._Optimizer.ADADELTA:
+                self.learner.sgd_optimizer = opt.AdaDelta(rho=self.rho)
+
+            elif self.opt_type == self._Optimizer.ADAM:
+                self.learner.sgd_optimizer = opt.Adam(beta1=self.beta1,
+                                                      beta2=self.beta2)
+
+            elif self.opt_type == self._Optimizer.ADAMAX:
+                self.learner.sgd_optimizer = opt.Adamax(beta1=self.beta1,
+                                                        beta2=self.beta2)
+            else:
+                self.learner.sgd_optimizer = opt.SGD()
 
     def set_data(self, data):
         """
@@ -422,6 +527,7 @@ class OWGradientDescent(OWWidget):
             alpha=self.alpha, stochastic=self.stochastic,
             theta=theta, step_size=self.step_size,
             intercept=(self.learner_name == "Linear regression"))
+        self.select_optimizer()
         self.replot()
         if theta is None:  # no previous theta exist
             self.change_theta(np.random.uniform(self.min_x, self.max_x),
@@ -445,6 +551,7 @@ class OWGradientDescent(OWWidget):
         if self.learner is not None:
             self.learner.stochastic = self.stochastic
         self.step_size_lock()
+        self._opt_changed()
 
     def change_step(self):
         if self.learner is not None:

--- a/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
+++ b/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
@@ -247,6 +247,13 @@ class TestOWGradientDescent(WidgetTest):
         w.stochastic_checkbox.click()
         self.assertFalse(w.learner.stochastic)
 
+        # Change optimizers
+        w.combobox_opt.currentIndexChanged.connect(w._opt_changed)
+        for i in range(w.combobox_opt.count()):
+            w.opt_type = i  # Set item
+            w.combobox_opt.setCurrentIndex(i)  # Fire signal
+            self.assertTrue(w.opt_type == i)  # Check index kept
+
         # just check if nothing happens when no learner
         self.send_signal("Data", None)
         self.assertIsNone(w.learner)

--- a/orangecontrib/educational/widgets/utils/gradient_descent.py
+++ b/orangecontrib/educational/widgets/utils/gradient_descent.py
@@ -1,7 +1,7 @@
 import numpy as np
 from scipy.optimize import fmin_l_bfgs_b
 
-from Orange.classification import Model
+import orangecontrib.educational.optimizers as opt
 
 
 class GradientDescent:
@@ -39,6 +39,7 @@ class GradientDescent:
         self.set_theta(theta)
         self.stochastic = stochastic
         self.stochastic_step_size = step_size
+        self.sgd_optimizer = opt.SGD()
 
     def set_data(self, data):
         """
@@ -112,7 +113,9 @@ class GradientDescent:
         # calculates gradient and modify theta
         grad = self.dj(self.theta, self.stochastic)
         if self.stochastic:
-            self.theta -= np.sum(np.float64(self.alpha) * grad, axis=0)
+            dj = np.sum(np.float64(self.alpha) * grad, axis=0)
+            self.sgd_optimizer.learning_rate = self.alpha
+            self.sgd_optimizer.update(dj, self.theta, None)
         else:
             self.theta -= self.alpha * grad
 

--- a/orangecontrib/educational/widgets/utils/tests/test_optimizers.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_optimizers.py
@@ -1,0 +1,128 @@
+import orangecontrib.educational.optimizers as opt
+
+import numpy as np
+import collections
+import unittest
+import copy
+
+__optimizers__ = [
+    opt.SGD(learning_rate=0.1),
+    opt.Momentum(learning_rate=0.1, momentum=0.5),
+    opt.NesterovMomentum(learning_rate=0.1, momentum=0.5),
+    opt.AdaGrad(learning_rate=0.1),
+    opt.RMSProp(learning_rate=0.01, rho=0.9, epsilon=1e-6),
+    opt.AdaDelta(learning_rate=1, rho=0.95, epsilon=1e-6),
+    opt.Adam(learning_rate=0.01, beta1=0.9, beta2=0.999, epsilon=1e-8),
+    opt.Adamax(learning_rate=0.01, beta1=0.9, beta2=0.999, epsilon=1e-8)
+    ]
+
+
+def dxf(X):
+    tensor = [0.1, 0.2, 0.3]
+    return tensor * X * 2  # f(x) = x^2 -> dx(f(x)) = 2x
+
+
+def dxf2(X):
+    return X*2
+
+
+class TestOptimizers(unittest.TestCase):
+
+    # These tests compare results on a toy problem to values
+    # calculated by the torch.optim package, using this script:
+    # https://gist.github.com/ebenolson/931e879ed38f257253d2
+
+    # Note: In 'optim.rmsprop' the running average 'm' (state.m) is initialized
+    # to ones. So we modified their code to initialize it to zero.
+
+    # Torch's reason: https://github.com/torch/optim/issues/87
+    # Our reason: "Follow the most common initialization"
+    torch_values = collections.OrderedDict()
+    torch_values['sgd'] = [0.81707280688755,
+                           0.6648326359915,
+                           0.5386151140949]
+
+    torch_values['momentum'] = [0.6848486952183,
+                                0.44803321781003,
+                                0.27431190123502]
+
+    torch_values['nesterov_momentum'] = [0.67466543592725,
+                                         0.44108468114241,
+                                         0.2769002108997]
+
+    torch_values['adagrad'] = [0.55373120047759,
+                               0.55373120041518,
+                               0.55373120039438]
+
+    torch_values['rmsprop'] = [0.83205403985348,
+                               0.83205322744821,
+                               0.83205295664444]
+
+    torch_values['adadelta'] = [0.95453237704725,
+                                0.9545237471374,
+                                0.95452214847397]
+
+    torch_values['adam'] = [0.90034973381771,
+                            0.90034969365796,
+                            0.90034968027137]
+
+    torch_values['adamax'] = [0.90211749000754,
+                              0.90211748762402,
+                              0.90211748682951]
+
+    def test_torch(self):
+        for _opt, torch in zip(__optimizers__, self.torch_values.values()):
+            print('Testing: %s' % _opt.__str__())  # Testing __str__
+
+            opt_copy = copy.copy(_opt)  # Shallow copy (test dependent)
+            x = np.asarray([1., 1., 1.], dtype=np.float64)  # Initial state
+
+            for _ in range(10):
+                opt_copy.update(dxf(x), x)
+            np.testing.assert_almost_equal(x, torch, decimal=4)
+
+    def test_convergence(self):
+        res = []
+        x0 = 100
+
+        # Test SGD optimizers too
+        for _opt in __optimizers__:
+            opt_copy = copy.copy(_opt)  # Shallow copy (test dependent)
+            x = np.asarray([x0], dtype=np.float64)  # Initial state
+            for _ in range(10):
+                opt_copy.update(dxf2(x), x)
+            res.append(x)
+
+        test = list(
+            map(lambda t: abs(t) < x0, res))
+        self.assertTrue(all(test))
+
+    def test_opt_cloner(self):  # Dumb test. Just for coverage
+        opt_1 = opt.create_opt(opt.SGD())
+        opt_1.learning_rate = 0.5
+        opt_2 = opt.create_opt(opt_1, opt_1.learning_rate)
+
+        self.assertIsInstance(opt_1, opt.SGD)
+        self.assertIsInstance(opt_2, opt.SGD)
+        self.assertTrue(opt_1.learning_rate == opt_2.learning_rate)
+
+    def test_params(self):  # Dumb test. Just for coverage
+        x0 = [10, 20, 30]
+        indices = np.arange(len(x0))
+
+        for _opt in __optimizers__:
+            opt_copy = copy.copy(_opt)  # Shallow copy (test dependent)
+            x = np.asarray(x0, dtype=np.float64)  # Initial state
+
+            for _ in range(10):
+                opt_copy.update(dxf2(x), x, indices)
+
+if __name__ == "__main__":
+    # # Test all
+    unittest.main()
+
+    # # Test single test
+    # suite = unittest.TestSuite()
+    # suite.addTest(TestOptimizers("test_convergence"))
+    # runner = unittest.TextTestRunner()
+    # runner.run(suite)


### PR DESCRIPTION
Added support for different SGD optimizers: Vanilla SGD, Momentum, Nesterov's Accelerated Gradient, AdaGrad, RMSProp, AdaDelta, Adam and Adamax.

This optimizers allow a faster convergence rate in many problems and try to escape from saddle points, making them more robust than vanilla SGD for many cases. Moreover, visualizing its behaviour comes in handy when we're trying to understand intuition behind their basis and how suitable they are to tackle a certain problem.
