### PR TITLE
JS widgets: don't bridge via QWidget but via thin QObject instead

### DIFF
--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -5,7 +5,7 @@ from os import path
 import time
 
 import numpy as np
-from PyQt4.QtCore import pyqtSlot, Qt, QThread, pyqtSignal
+from PyQt4.QtCore import pyqtSlot, Qt, QThread, pyqtSignal, QObject
 from PyQt4.QtGui import QSizePolicy, QPixmap, QColor, QIcon
 
 from Orange.widgets.utils import itemmodels
@@ -53,8 +53,16 @@ class Scatterplot(highcharts.Highchart):
                           'highcharts-contour.js'), 'r') as f:
             contours_js = f.read()
 
+        class Bridge(QObject):
+            @pyqtSlot(float, float)
+            def chart_clicked(self, x, y):
+                """
+                Function is called from javascript when click event happens
+                """
+                click_callback(x, y)
+
         super().__init__(enable_zoom=True,
-                         bridge=self,
+                         bridge=Bridge(),
                          enable_select='',
                          chart_events_click=self.js_click_function,
                          plotOptions_series_states_hover_enabled=False,
@@ -67,13 +75,6 @@ class Scatterplot(highcharts.Highchart):
     def chart(self, *args, **kwargs):
         self.count_replots += 1
         super(Scatterplot, self).chart(*args, **kwargs)
-
-    @pyqtSlot(float, float)
-    def chart_clicked(self, x, y):
-        """
-        Function is called from javascript when click event happens
-        """
-        self.click_callback(x, y)
 
     def remove_series(self, idx):
         """

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -41,7 +41,6 @@ class Scatterplot(highcharts.Highchart):
             contour_js = f.read()
 
         super().__init__(enable_zoom=False,
-                         bridge=self,
                          enable_select='',
                          plotOptions_series_cursor="move",
                          javascript=contour_js,

--- a/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
+++ b/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
@@ -290,7 +290,7 @@ class TestOWGradientDescent(WidgetTest):
         # change theta
         w.change_theta(1, 1)
         assert_array_equal(w.learner.theta, [1, 1])
-        w.scatter.chart_clicked(1, 2)
+        w.scatter.bridge.chart_clicked(1, 2)
         assert_array_equal(w.learner.theta, [1, 2])
 
         # just check if nothing happens when no learner

--- a/orangecontrib/educational/widgets/tests/test_owkmeans.py
+++ b/orangecontrib/educational/widgets/tests/test_owkmeans.py
@@ -289,18 +289,18 @@ class TestOWKmeans(GuiTest):
     def test_scatter_chart_clicked(self):
         self.widget.set_data(self.data)
         self.widget.centroid_numbers_spinner.setValue(1)
-        self.widget.scatter.chart_clicked(1, 2)
+        self.widget.scatter.bridge.chart_clicked(1, 2)
 
         self.assertEqual(self.widget.k_means.k, 2)
 
         self.widget.set_data(None)
-        self.widget.scatter.chart_clicked(1, 2)
+        self.widget.scatter.bridge.chart_clicked(1, 2)
         self.assertEqual(self.widget.k_means.k, 2)  # no changes when no data
 
     def test_scatter_point_dropped(self):
         self.widget.set_data(self.data)
         self.widget.centroid_numbers_spinner.setValue(1)
-        self.widget.scatter.point_dropped(0, 1, 2)
+        self.widget.scatter.bridge.point_dropped(0, 1, 2)
 
         self.assertEqual(self.widget.k_means.k, 1)
 


### PR DESCRIPTION
Refs: "WebView/WebEngine: don't permit exposing QWidgets" in https://github.com/biolab/orange3/pull/1799