### PR TITLE
Provide encoding='utf-8' when opening text files ...

### DIFF
--- a/orangecontrib/educational/widgets/highcharts/highcharts.py
+++ b/orangecontrib/educational/widgets/highcharts/highcharts.py
@@ -166,7 +166,7 @@ class Highchart(WebviewWidget):
                                   enable_point_select, enable_rect_select,
                                   kwargs)
 
-        with open(self._HIGHCHARTS_HTML) as html:
+        with open(self._HIGHCHARTS_HTML, encoding='utf-8') as html:
             self.setHtml(html.read() % dict(javascript=javascript,
                                             options=json(options)),
                          self.toFileURL(dirname(self._HIGHCHARTS_HTML)) + '/')

--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -48,9 +48,8 @@ class Scatterplot(Highchart):
     def __init__(self, click_callback, **kwargs):
 
         # read javascript for drag and drop
-        with open(
-                path.join(path.dirname(__file__), 'resources',
-                          'highcharts-contour.js'), 'r') as f:
+        with open(path.join(path.dirname(__file__), 'resources', 'highcharts-contour.js'),
+                  encoding='utf-8') as f:
             contours_js = f.read()
 
         class Bridge(QObject):

--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -67,8 +67,8 @@ class Scatterplot(Highchart):
     def __init__(self, click_callback, drop_callback, **kwargs):
 
         # read javascript for drag and drop
-        with open(path.join(path.dirname(__file__), 'resources',
-                            'draggable-points.js'), 'r') as f:
+        with open(path.join(path.dirname(__file__), 'resources', 'draggable-points.js'),
+                  encoding='utf-8') as f:
             drag_drop_js = f.read()
 
         class Bridge(QObject):

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -36,9 +36,8 @@ class Scatterplot(Highchart):
     """
 
     def __init__(self, **kwargs):
-        with open(path.join(
-                path.dirname(__file__), 'resources',
-                'highcharts-contour.js'), 'r') as f:
+        with open(path.join(path.dirname(__file__), 'resources', 'highcharts-contour.js'),
+                  encoding='utf-8') as f:
             contour_js = f.read()
 
         super().__init__(enable_zoom=False,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ ENTRY_POINTS = {
     # Entry points that marks this package as an orange add-on. If set, addon will
     # be shown in the add-ons manager even if not published on PyPi.
     'orange3.addon': (
-        'eduactional = orangecontrib.eduactional',
+        'educational = orangecontrib.educational',
     ),
     # Entry point used to specify packages containing tutorials accessible
     # from welcome screen. Tutorials are saved Orange Workflows (.ows files).


### PR DESCRIPTION
... otherwise Python uses possibly incompatible system default.

Fixes https://github.com/biolab/orange3-educational/issues/33