### PR TITLE
[FIX] Category Icon: remove some lines which causes warning message

### DIFF
--- a/orangecontrib/educational/widgets/icons/category.svg
+++ b/orangecontrib/educational/widgets/icons/category.svg
@@ -3,11 +3,6 @@
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 width="48px" height="48px" viewBox="0 0 48 48" enable-background="new 0 0 48 48" xml:space="preserve">
-<g id="zXDtGm_1_">
-	
-		<image overflow="visible" width="253" height="282" id="zXDtGm" xlink:href="EC2EE3FB7160215B.jpg"  transform="matrix(1 0 0 1 -581.1807 153.3486)">
-	</image>
-</g>
 <path fill-rule="evenodd" clip-rule="evenodd" fill="#333333" d="M7.254,19.292c0,1.914-0.022,3.63,0.022,5.345
 	c0.007,0.273,0.257,0.6,0.484,0.801c0.873,0.773,0.975,1.641,0.583,2.711c-0.188,0.514-0.21,1.164-0.09,1.703
 	c0.637,2.875,1.085,5.766,1.064,8.717c-0.01,1.539-0.514,2.242-2.008,2.455c-0.775,0.107-1.621,0.092-2.375-0.102


### PR DESCRIPTION
##### Issue
Each time Orange starts this message appears in a console:

> couldn't create image from  "EC2EE3FB7160215B.jpg"

##### Description of changes
Some lines removed in `category.svg` file.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
