### PR TITLE
[FIX] Gradient Descent: do not crash when auto play runs

### DIFF
--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -136,7 +136,8 @@ class Autoplay(QThread):
         """
         Stepping through the algorithm until converge or user interrupts
         """
-        while (not self.ow_gradient_descent.learner.converged and
+        while (self.ow_gradient_descent.learner and
+               not self.ow_gradient_descent.learner.converged and
                self.ow_gradient_descent.auto_play_enabled and
                self.ow_gradient_descent.learner.step_no <= 500):
             self.ow_gradient_descent.step_trigger.emit()

--- a/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
+++ b/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
@@ -850,3 +850,13 @@ class TestOWGradientDescent(WidgetTest):
         self.process_events(_svg_ready)
         w.send_report()
         self.process_events()
+
+    def test_auto_play_data_removed(self):
+        """
+        Do not crash if auto play runs and data is removed.
+        GH-47
+        """
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.iris)
+        w.auto_play_button.click()
+        self.send_signal(w.Inputs.data, None)


### PR DESCRIPTION
##### Issue
Connect **File** and **Gradient Descent**. Click _Run_ and then remove data connection between these two widgets. Orange then crashes.


##### Description of changes
Stop running when there is no data anymore.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
