### PR TITLE
[FIX] Gradient Descent: handle thread if widget removed

### DIFF
--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -139,7 +139,10 @@ class Autoplay(QThread):
         while (not self.ow_gradient_descent.learner.converged and
                self.ow_gradient_descent.auto_play_enabled and
                self.ow_gradient_descent.learner.step_no <= 500):
-            self.ow_gradient_descent.step_trigger.emit()
+            try:
+                self.ow_gradient_descent.step_trigger.emit()
+            except RuntimeError:
+                return
             time.sleep(2 - self.ow_gradient_descent.auto_play_speed)
         self.ow_gradient_descent.stop_auto_play_trigger.emit()
 


### PR DESCRIPTION
##### Issue
Connect **File** and **Gradient Descent**.  Click _Run_ button and then remove **Gradient Descent** widget. Then Orange crashes because a thread is still working and there is no widget anymore.


##### Description of changes
Solved by `try except`.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
