### PR TITLE
[FIX] Polynomial Classification: do not draw contours if no data

### DIFF
--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -438,6 +438,8 @@ class OWPolynomialClassification(OWBaseLearner):
         Function constructs contour lines
         """
         self.scatter.remove_contours()
+        if not self.data:
+            return
         if self.contours_enabled:
             is_tree = type(self.learner) in [RandomForestLearner, TreeLearner]
             # tree does not need smoothing

--- a/orangecontrib/educational/widgets/tests/test_owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/tests/test_owpolynomialclassification.py
@@ -599,3 +599,10 @@ class TestOWPolynomialClassification(WidgetTest):
         learner = SVMLearner()
         self.send_signal(w.Inputs.learner, learner)
         self.assertFalse(w.Error.no_classifier.is_shown())
+
+    def test_no_data_contour(self):
+        """
+        Do not crash when there is no data and one want to draw contours.
+        GH-50
+        """
+        self.widget.contours_enabled_checkbox.click()


### PR DESCRIPTION
##### Issue
Put **Polynomial Classification** on canvas. Click checkbox _Show contours_. The widget crashes.

##### Description of changes
Do not try to draw contours if there is no data.

##### Includes
- [X] Code changes
- [x] Tests
- [ ] Documentation
