### PR TITLE
Remove setting the number of decimals in ContinuousVariable

### DIFF
--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -827,7 +827,7 @@ class OWGradientDescent(OWWidget):
         """
         if self.learner is not None and self.learner.theta is not None:
             domain = Domain(
-                    [ContinuousVariable("Coefficients", number_of_decimals=7)],
+                    [ContinuousVariable("Coefficients")],
                     metas=[StringVariable("Name")])
             names = ["theta 0", "theta 1"]
 

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -607,8 +607,7 @@ class OWPolynomialClassification(OWBaseLearner):
                 hasattr(self.model, 'skl_model')):
             model = self.model.skl_model
             domain = Domain(
-                [ContinuousVariable("coef", number_of_decimals=7)],
-                metas=[StringVariable("name")])
+                [ContinuousVariable("coef")], metas=[StringVariable("name")])
             coefficients = (model.intercept_.tolist() +
                             model.coef_[0].tolist())
 

--- a/orangecontrib/educational/widgets/owpolynomialregression.py
+++ b/orangecontrib/educational/widgets/owpolynomialregression.py
@@ -332,7 +332,7 @@ class OWUnivariateRegression(OWBaseLearner):
             elif hasattr(model, "skl_model"):
                 model = model.skl_model
         if model is not None and hasattr(model, "coef_"):
-            domain = Domain([ContinuousVariable("coef", number_of_decimals=7)],
+            domain = Domain([ContinuousVariable("coef")],
                             metas=[StringVariable("name")])
             coefs = [model.intercept_ + model.coef_[0]] + list(model.coef_[1:])
             names = ["1", x_label] + \


### PR DESCRIPTION
Setting the number of decimals to 7 is no longer necessary: after https://github.com/biolab/orange3/pull/3574, values are printed with `%g` by default.