### PR TITLE
Polynomial classification: Fix crash on missing values

### DIFF
--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -331,7 +331,7 @@ class OWPolynomialClassification(OWBaseLearner):
             dict(
                 data=[list(p.attributes())
                       for p in sd
-                      if (int(p.metas[0]) == _class and
+                      if (p.metas[0] == _class and
                           all(v is not None for v in p.attributes()))],
                 type="scatter",
                 zIndex=10,


### PR DESCRIPTION
##### Issue

Polynomial classification crashes if the variable for coloring has missing values. From Sentry:

```
ValueError:  cannot convert float NaN to integer
(1 additional frame(s) were not displayed)
...
  Module "orangecontrib.educational.widgets.owpolynomialclassification", in set_data

    self.apply()
  Module "orangecontrib.educational.widgets.owpolynomialclassification", in apply

    self.replot()
  Module "orangecontrib.educational.widgets.owpolynomialclassification", in replot

    for _class in range(len(sd.domain.metas[0].values))]
  Module "orangecontrib.educational.widgets.owpolynomialclassification", in <listcomp>

    for _class in range(len(sd.domain.metas[0].values))]
  Module "orangecontrib.educational.widgets.owpolynomialclassification", in <listcomp>

    if (int(p.metas[0]) == _class and
```

##### Description of changes

Conversion to `int` is not necessary, I suppose.

**TODO**: Show points with missing color data as grey.

**TODO**: Tests.

@PrimozGodec, I don't have this add-on installed because `python setup.py develop` for Educational addon used to ruin my environment a month or two ago. Do I remember correctly that multiple add-ons had this problem, but it is now fixed?

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
