### PR TITLE
owkmeans: Add 'kmeans' (without '-') keyword for quick menu search

### DIFF
--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -130,6 +130,7 @@ class OWKmeans(OWWidget):
 
     name = "Interactive k-Means"
     description = "Widget demonstrates working of k-means algorithm."
+    keywords = ["kmeans"]
     icon = "icons/InteractiveKMeans.svg"
     want_main_area = False
     priority = 300


### PR DESCRIPTION
##### Issue
Should one type 'kmeans' as a quick menu search query, the educational k-Means widget would not appear.


##### Description of changes
A 'kmeans' keyword was added to the widget.

##### Includes
- [X] Code changes
