### PR TITLE
travis: update versions for test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,15 @@ matrix:
   include:
 
     - python: '3.6'
-      env: ORANGE="3.16.0"
+      env: ORANGE="3.20.0"
 
     - python: '3.6'
       env: ORANGE="release"
 
-    - python: '3.6'
+    - python: '3.7'
+      env: ORANGE="release"
+
+    - python: '3.7'
       env: ORANGE="master"
 
 cache:


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
- Add-on not tested on Python 3.7.
- Orange 3.16 is very old and does not contain all required components. 

##### Description of changes

- Testing on Python 3.7
- Oldest supported version of Orange changed to 3.20.

##### Includes
- [ ] Code changes
- [X] Tests
- [ ] Documentation
