### PR TITLE
Changing minimal Orange version to 3.21.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
 
     - python: '3.6'
-      env: ORANGE="3.20.0"
+      env: ORANGE="3.21.0"
 
     - python: '3.6'
       env: ORANGE="release"

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ DATA_FILES = [
 ]
 
 INSTALL_REQUIRES = [
-    'Orange3',
+    'Orange3 >=3.21.0',
     'BeautifulSoup4',
 ]
 


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
For merging https://github.com/biolab/orange3-educational/pull/73 it would be great to have Orange version at least 3.21.0 - some new signals. 

##### Description of changes
Changing minimal Orange version to 3.21.0

##### Includes
- [ ] Code changes
- [x] Tests
- [ ] Documentation
