### PR TITLE
[FIX] Fix import for report

### DIFF
--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -1,6 +1,5 @@
 import operator
 
-from Orange.canvas import report
 from os import path
 import time
 
@@ -20,6 +19,11 @@ from Orange.widgets import settings
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.preprocess.preprocess import Normalize
 from scipy.interpolate import splprep, splev
+
+try:
+    from orangewidget.report import report
+except ImportError:
+    from Orange.canvas import report
 
 from orangecontrib.educational.widgets.utils.color_transform import (
     rgb_to_hex, hex_to_rgb)

--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -10,7 +10,11 @@ import Orange
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
 from Orange.data import DiscreteVariable, ContinuousVariable, Table, Domain
 from Orange.widgets import gui, settings, widget
-from Orange.canvas import report
+
+try:
+    from orangewidget.report import report
+except ImportError:
+    from Orange.canvas import report
 
 from orangecontrib.educational.widgets.utils.kmeans import Kmeans
 from orangecontrib.educational.widgets.utils.color_transform import \
@@ -213,7 +217,7 @@ class OWKmeans(OWWidget):
             self.step_box, self, "Step Back", callback=self.step_back)
 
         self.run_box = gui.widgetBox(self.controlArea, "Run")
-        
+
         self.auto_play_speed_spinner = gui.hSlider(
             self.run_box, self, 'auto_play_speed', label='Speed:',
             minValue=0, maxValue=1.91, step=0.1, intOnly=False,

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -19,7 +19,11 @@ from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 from Orange.classification import (LogisticRegressionLearner, Learner,
                                    RandomForestLearner, TreeLearner)
 from Orange.widgets.widget import Msg, OWWidget, Input, Output
-from Orange.canvas import report
+
+try:
+    from orangewidget.report import report
+except ImportError:
+    from Orange.canvas import report
 
 from orangecontrib.educational.widgets.utils.polynomialtransform \
     import PolynomialTransform

--- a/orangecontrib/educational/widgets/owpolynomialregression.py
+++ b/orangecontrib/educational/widgets/owpolynomialregression.py
@@ -19,7 +19,11 @@ from Orange.widgets.utils import itemmodels
 from Orange.widgets.utils.owlearnerwidget import OWBaseLearner
 from Orange.widgets.utils.sql import check_sql_input
 from Orange.widgets.widget import OWWidget, Msg, Input, Output
-from Orange.canvas import report
+
+try:
+    from orangewidget.report import report
+except ImportError:
+    from Orange.canvas import report
 
 
 class OWUnivariateRegression(OWBaseLearner):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
As of https://github.com/biolab/orange3/pull/3772 widget report is no longer in Orange.canvas.report

##### Description of changes
Now we try to import both `from orangewidget.report import report` and older report that addon is compatible with an older version of Orange.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
