### PR TITLE
Docs: removed deprecated source_parsers

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,16 +32,11 @@ import shlex
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'recommonmark'
 ]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['templates']
-
-# The suffix(es) of source filenames.
-# You can specify multiple suffix as a list of string:
-# source_suffix = ['.rst', '.md']
-source_suffix = ['.rst', '.md']
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
 
 # The encoding of source files.
 source_encoding = 'utf-8'


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
source_parsers is deprecated in sphinx config

##### Description of changes

source_parsers is now removed. recommonmark is moved to extensions

##### Includes
- [ ] Code changes
- [ ] Tests
- [x] Documentation
