### PR TITLE
LogisticRegression: limit to two class values only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   include:
 
     - python: '3.6'
-      env: ORANGE="3.24.0"
+      env: ORANGE="3.25.1"
 
     - python: '3.6'
       env: ORANGE="release"

--- a/orangecontrib/educational/widgets/utils/logistic_regression.py
+++ b/orangecontrib/educational/widgets/utils/logistic_regression.py
@@ -12,8 +12,16 @@ class LogisticRegression(GradientDescent):
     which allow to perform algorithm step by step
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
+    def __init__(self, data=None, **kwargs):
+        super().__init__(data=data, **kwargs)
+        self._check_data(data)
+
+    @staticmethod
+    def _check_data(data):
+        if data is not None and len(data.domain.class_var.values) > 2:
+            raise ValueError(
+                "This implementation is made for class with only two values"
+            )
 
     @property
     def model(self):
@@ -24,6 +32,10 @@ class LogisticRegression(GradientDescent):
             return None
         else:
             return LogisticRegressionModel(self.theta, self.domain)
+
+    def set_data(self, data):
+        self._check_data(data)
+        super().set_data(data)
 
     def j(self, theta):
         """
@@ -64,6 +76,7 @@ class LogisticRegression(GradientDescent):
         z_mod = np.maximum(z_mod, -20)
 
         return 1.0 / (1 + np.exp(- z_mod))
+
 
 class LogisticRegressionModel(Model):
 

--- a/orangecontrib/educational/widgets/utils/tests/test_linear_regression.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_linear_regression.py
@@ -8,7 +8,7 @@ from numpy.testing import *
 import numpy as np
 
 
-class TestLogisticRegression(unittest.TestCase):
+class TestLinearRegression(unittest.TestCase):
 
     def setUp(self):
         self.housing = Normalize()(Table('housing'))

--- a/orangecontrib/educational/widgets/utils/tests/test_logistic_regression.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_logistic_regression.py
@@ -1,5 +1,5 @@
 import unittest
-from Orange.data import Table
+from Orange.data import Table, Domain, DiscreteVariable
 from orangecontrib.educational.widgets.utils.logistic_regression import \
     LogisticRegression
 from numpy.testing import *
@@ -10,6 +10,11 @@ class TestLogisticRegression(unittest.TestCase):
 
     def setUp(self):
         self.iris = Table('iris')
+        class_var = DiscreteVariable(
+            "iris", values=self.iris.domain.class_var.values[:2]
+        )
+        domain = Domain(self.iris.domain.attributes, class_var)
+        self.iris = Table.from_table(domain, self.iris[:100])
         self.logistic_regression = LogisticRegression()
 
     def test_model(self):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Logistic regression is made to work on two classes only but test provided case with more classes

##### Description of changes
- test changed
- logistic regression error on more classes

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
