### PR TITLE
Random data: Add output summary, fix adding variables on keydown on combo

### DIFF
--- a/orangecontrib/educational/widgets/owrandomdata.py
+++ b/orangecontrib/educational/widgets/owrandomdata.py
@@ -14,6 +14,7 @@ from AnyQt.QtGui import QIntValidator, QDoubleValidator
 
 from Orange.data import Table, ContinuousVariable, Domain, DiscreteVariable
 from Orange.widgets.settings import Setting
+from Orange.widgets.utils.state_summary import format_summary_details
 from Orange.widgets.utils.widgetpreview import WidgetPreview
 from Orange.widgets.widget import OWWidget, Output, Msg
 from Orange.widgets import gui
@@ -472,6 +473,13 @@ class OWRandomData(OWWidget):
             domain = Domain(list(chain(*attrs)))
             data = Table(domain, np.hstack(parts))
             self.Error.sampling_error.clear()
+
+        if data is None:
+            self.info.set_output_summary(self.info.NoOutput, "")
+        else:
+            self.info.set_output_summary(
+                len(data), format_summary_details(data))
+
         self.Outputs.data.send(data)
 
     def pack_editor_settings(self):

--- a/orangecontrib/educational/widgets/owrandomdata.py
+++ b/orangecontrib/educational/widgets/owrandomdata.py
@@ -411,8 +411,12 @@ class OWRandomData(OWWidget):
         self.scroll_area.setWidget(self.editor_vbox)
         self.controlArea.layout().addWidget(self.scroll_area)
 
+        class IgnoreWheelCombo(QComboBox):
+            def wheelEvent(self, event):
+                event.ignore()
+
         # self.add_combo is needed so that tests can manipulate it
-        combo = self.add_combo = QComboBox()
+        combo = self.add_combo = IgnoreWheelCombo()
         combo.addItem("Add more variables ...")
         combo.addItems(list(distributions))
         combo.currentTextChanged.connect(self.on_add_distribution)

--- a/orangecontrib/educational/widgets/owrandomdata.py
+++ b/orangecontrib/educational/widgets/owrandomdata.py
@@ -415,6 +415,7 @@ class OWRandomData(OWWidget):
         combo.addItem("Add more variables ...")
         combo.addItems(list(distributions))
         combo.currentTextChanged.connect(self.on_add_distribution)
+        combo.setFocusPolicy(Qt.NoFocus)
         self.controlArea.layout().addWidget(combo)
         gui.separator(self.controlArea, 16)
 

--- a/orangecontrib/educational/widgets/tests/test_owrandomdata.py
+++ b/orangecontrib/educational/widgets/tests/test_owrandomdata.py
@@ -2,7 +2,7 @@
 # pylint: disable=abstract-method, attribute-defined-outside-init
 
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 from collections import Counter
 
 from Orange.widgets.tests.base import WidgetTest, GuiTest
@@ -183,6 +183,7 @@ class TestParametersEditor(GuiTest):
     def test_prepare_variables_is_abstract(self):
         e = MockEditor()
         self.assertRaises(NotImplementedError, e.prepare_variables, {}, 3)
+
 
 class TestParametersEditorContinuous(GuiTest):
     def test_prepare_variables(self):
@@ -458,6 +459,22 @@ class TestOWRandomData(WidgetTest):
         widget.remove_editor()
         widget.pack_editor_settings()
         self.assertEqual(widget.distributions, [])
+
+    def test_output_summary(self):
+        widget = self.widget
+        setsum = widget.info.set_output_summary = Mock()
+        widget.n_instances = 7
+        widget.generate()
+        self.assertEqual(setsum.call_args[0][0], 7)
+        widget.n_instances = 5
+        widget.generate()
+        self.assertEqual(setsum.call_args[0][0], 5)
+
+        with patch.object(widget, "sender", new=lambda: widget.editors[0]):
+            while widget.editors:
+                widget.remove_editor()
+
+        self.assertIs(setsum.call_args[0][0], widget.info.NoOutput)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
##### Issue

Fixes #97.

##### Description of changes

1. Combo value was changed when the down key was pressed, and the `currentTextChanged` triggers adding a variables. This has been resolved by setting the focus policy to none.
2. Output summary is added and tested.

##### Includes
- [X] Code changes
- [X] Tests