### PR TITLE
Fix enka to not use time.clock anymore

### DIFF
--- a/orangecontrib/educational/widgets/ow1ka.py
+++ b/orangecontrib/educational/widgets/ow1ka.py
@@ -28,10 +28,10 @@ except ImportError:  # WebKit and before wait() was toplevel
     from AnyQt.QtCore import QEventLoop
 
     def wait(until: callable, timeout=5000):
-        started = time.clock()
+        started = time.perf_counter()
         while not until():
             qApp.processEvents(QEventLoop.ExcludeUserInputEvents)
-            if (time.clock() - started) * 1000 > timeout:
+            if (time.perf_counter() - started) * 1000 > timeout:
                 raise TimeoutError()
 
 

--- a/orangecontrib/educational/widgets/tests/test_ow1ka.py
+++ b/orangecontrib/educational/widgets/tests/test_ow1ka.py
@@ -20,3 +20,7 @@ class TestOW1ka(WidgetTest):
 
     def test_widget_load(self):
         self.assertIsNotNone(self.widget)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Enka still uses `time.clock` which was deprecated in Python 3.3 and is removed in Python 3.8.

##### Description of changes
Replace with perf_counter

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
