### PR TITLE
Interactive K-Means: Remove Highchart, other improvements

### DIFF
--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -197,10 +197,6 @@ class OWKmeans(OWWidget):
         self.cby = gui.comboBox(value='attr_y', **opts)
 
         self.centroids_box = gui.widgetBox(self.controlArea, "Centroids")
-        self.centroid_numbers_spinner = gui.spin(
-            self.centroids_box, self, 'number_of_clusters',
-            minv=1, maxv=10, step=1, label='Number of clusters:',
-            alignment=Qt.AlignRight, callback=self.number_of_clusters_change)
         self.restart_button = gui.button(
             self.centroids_box, self, "Randomize Positions",
             callback=self.restart)
@@ -341,10 +337,13 @@ class OWKmeans(OWWidget):
         self.animate_membership()
         self.send_data()
 
+    def max_clusters(self):
+        if self.k_means is None:
+            return 10
+        return max(10, len(self.k_means.data))
+
     def on_centroid_add(self, x, y):
-        if not self.data or \
-                self.number_of_clusters \
-                == self.controls.number_of_clusters.maximum():
+        if not self.data or self.number_of_clusters == self.max_clusters():
             return
 
         self.number_of_clusters += 1
@@ -492,10 +491,8 @@ class OWKmeans(OWWidget):
         self.set_disabled_all(False)
         self.attr_x, self.attr_y = self.var_model[:2]
 
-        max_clusters = min(10, len(self.data))
-        self.controls.number_of_clusters.setMaximum(max_clusters)
-        if self.number_of_clusters > max_clusters:
-            self.number_of_clusters = max_clusters
+        if self.number_of_clusters > self.max_clusters():
+            self.number_of_clusters = self.max_clusters()
         self.k_means = Kmeans(self.concat_x_y())
 
         self.color_map = np.arange(self.k_means.k)

--- a/orangecontrib/educational/widgets/tests/test_owkmeans.py
+++ b/orangecontrib/educational/widgets/tests/test_owkmeans.py
@@ -167,7 +167,7 @@ class TestOWKmeans(WidgetTest):
         self.widget.set_data(data1)
         self.assertIsNone(self.widget.reduced_data)
         self.assertIsNone(self.widget.k_means)
-        self.assertEqual(self.widget.var_model.rowCount(), 1)
+        self.assertTrue(self.widget.Error.num_features.is_shown())
 
     def test_data_no_non_nan_data(self):
         self.dataxy[:5, 0] = np.nan
@@ -175,6 +175,7 @@ class TestOWKmeans(WidgetTest):
         self.send_signal(self.widget.Inputs.data, self.dataxy)
         self.assertIsNone(self.widget.reduced_data)
         self.assertIsNone(self.widget.k_means)
+        self.assertTrue(self.widget.Error.no_nonnan_data.is_shown())
 
     def test_restart(self):
         self.widget.set_data(self.data)

--- a/orangecontrib/educational/widgets/tests/test_owkmeans.py
+++ b/orangecontrib/educational/widgets/tests/test_owkmeans.py
@@ -1,342 +1,192 @@
-from Orange.widgets.tests.base import WidgetTest
-import Orange
-from Orange.data import Domain, Table
-from Orange.data.domain import ContinuousVariable
+import unittest
+from unittest.mock import Mock
+
 import numpy as np
+
+from Orange.widgets.tests.base import WidgetTest
+from Orange.data import Domain, ContinuousVariable, Table
+
+from orangecontrib.educational.widgets import owkmeans
 from orangecontrib.educational.widgets.owkmeans import OWKmeans
+
+# No animations
+owkmeans.AnimateNumpy.__call__ = lambda self: self.done(self.final)
 
 
 class TestOWKmeans(WidgetTest):
     def setUp(self):
         self.widget = self.create_widget(OWKmeans)  # type: OWKmeans
-        self.data = Orange.data.Table.from_file("iris")
+        self.data = Table("iris")
+        domain = Domain(attributes=self.data.domain.attributes[:2],
+                        class_vars=self.data.domain.class_vars)
+        self.data2 = self.data.transform(domain)
+        domain = Domain([ContinuousVariable(n) for n in "xy"])
+        self.dataxy = Table.from_numpy(domain, np.arange(20).reshape(10, 2))
 
-    def test_button_labels(self):
-        self.widget.set_data(self.data)
-        self.widget.centroid_numbers_spinner.setValue(4)
+    def test_simplify_widget(self):
+        def on_iris(nattrs):
+            self.assertIs(w.attr_x, self.data.domain[0])
+            self.assertIs(w.attr_y, self.data.domain[1])
+            self.assertIs(w.variables_box.isHidden(), nattrs <= 2)
+            axes = ("bottom", "left")
+            for axis, attr in zip(axes, (w.attr_x, w.attr_y)):
+                axis = w.plot.getAxis(axis)
+                self.assertTrue(axis.label.isVisible())
+                self.assertTrue(axis.label.toPlainText(), attr.name)
 
-        self.assertEqual(self.widget.step_button.text(),
-                         self.widget.STEP_BUTTONS[1])
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+        on_iris(4)
 
-        # make step
-        self.widget.step_button.click()
-        self.assertEqual(self.widget.step_button.text(),
-                         self.widget.STEP_BUTTONS[0])
+        self.send_signal(w.Inputs.data, self.data2)
+        on_iris(2)
 
-        # make next step
-        self.widget.step_button.click()
-        self.assertEqual(self.widget.step_button.text(),
-                         self.widget.STEP_BUTTONS[1])
+        self.send_signal(w.Inputs.data, self.data)
+        on_iris(4)
 
-        # make step to recompute centroids and then move one centroid (in graph)
-        # automatic step have to ber preformed
-        self.widget.step_button.click()
-        self.widget.centroid_dropped(0, 1, 1)
-        self.assertEqual(self.widget.step_button.text(),
-                         self.widget.STEP_BUTTONS[1])
+        self.send_signal(w.Inputs.data, self.dataxy)
+        self.assertIs(w.attr_x, self.dataxy.domain[0])
+        self.assertIs(w.attr_y, self.dataxy.domain[1])
+        self.assertTrue(w.variables_box.isHidden())
+        axes = ("bottom", "left")
+        for axis, attr in zip(axes, (w.attr_x, w.attr_y)):
+            axis = w.plot.getAxis(axis)
+            self.assertFalse(axis.label.isVisible())
 
-        # make step to recompute centroids and then move one centroid (in graph)
-        # automatic step have to ber preformed
-        self.widget.step_button.click()
-        self.widget.graph_clicked(1, 1)
-        self.assertEqual(self.widget.step_button.text(),
-                         self.widget.STEP_BUTTONS[1])
+        self.send_signal(w.Inputs.data, self.data)
+        on_iris(4)
 
-    def test_boxes_disabling(self):
-        """
-        Check if disabling depending on input is correct
-        """
+    def test_step(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+        w.send_data = Mock()
+        w._update_buttons = Mock()
 
-        # none input
-        self.widget.set_data(None)
-        self.assertEqual(self.widget.variables_box.isEnabled(), False)
-        self.assertEqual(self.widget.centroids_box.isEnabled(), False)
-        self.assertEqual(self.widget.step_box.isEnabled(), False)
-        self.assertEqual(self.widget.run_box.isEnabled(), False)
+        kmeans = w.k_means
+        klass = type(w.k_means)
+        w.step()
+        w.send_data.assert_called()
+        w._update_buttons.assert_called()
+        w.send_data.reset_mock()
+        w._update_buttons.reset_mock()
+        self.assertIs(kmeans.history[-1].step, klass.move_centroids)
 
-        # if data provided
-        self.widget.set_data(self.data)
-        self.assertEqual(self.widget.variables_box.isEnabled(), True)
-        self.assertEqual(self.widget.centroids_box.isEnabled(), True)
-        self.assertEqual(self.widget.step_box.isEnabled(), True)
-        self.assertEqual(self.widget.run_box.isEnabled(), True)
+        w.step()
+        w.send_data.assert_called()
+        w._update_buttons.assert_called()
+        w.send_data.reset_mock()
+        w._update_buttons.reset_mock()
+        self.assertIs(kmeans.history[-1].step, klass.assign_membership)
 
-        # if too les continuous attributes
-        domain = Orange.data.Domain(self.data.domain.attributes[:1],
-                                    self.data.domain.class_var)
-        data1 = Orange.data.Table.from_table(domain, self.data)
-        self.widget.set_data(data1)
-        self.assertEqual(self.widget.variables_box.isEnabled(), False)
-        self.assertEqual(self.widget.centroids_box.isEnabled(), False)
-        self.assertEqual(self.widget.step_box.isEnabled(), False)
-        self.assertEqual(self.widget.run_box.isEnabled(), False)
+    def test_step_back(self):
+        w = self.widget
+        self.send_signal(w.Inputs.data, self.data)
+        kmeans = w.k_means
 
-        # if too much clusters for data
-        self.widget.number_of_clusters = 3
-        self.widget.set_data(self.data[:2])
-        self.assertEqual(self.widget.variables_box.isEnabled(), True)
-        self.assertEqual(self.widget.centroids_box.isEnabled(), True)
-        self.assertEqual(self.widget.step_box.isEnabled(), False)
-        self.assertEqual(self.widget.run_box.isEnabled(), False)
+        centroids0 = kmeans.centroids.copy()
+        clusters0 = kmeans.clusters.copy()
 
-    def test_no_data(self):
-        """
-        Check if everything ok when no data
-        """
-        self.widget.set_data(None)
-        self.assertEqual(self.widget.k_means, None)
-        self.assertEqual(self.widget.cbx.count(), 0)
-        self.assertEqual(self.widget.cby.count(), 0)
+        w.step()
+        centroids1 = kmeans.centroids.copy()
+        clusters1 = kmeans.clusters.copy()
 
-        # if too les continuous attributes
-        domain = Orange.data.Domain(self.data.domain.attributes[:1],
-                                    self.data.domain.class_var)
-        data1 = Orange.data.Table.from_table(domain, self.data)
-        self.widget.set_data(data1)
-        self.assertEqual(self.widget.k_means, None)
-        self.assertEqual(self.widget.cbx.count(), 0)
-        self.assertEqual(self.widget.cby.count(), 0)
+        w.step()
 
-    def test_combo_box(self):
-        """
-        Check if combo box contains proper number of attributes
-        """
-        num_continuous_attributes = sum(
-            True for var in self.data.domain.attributes
-            if isinstance(var, ContinuousVariable))
-        self.widget.set_data(self.data)
-        if num_continuous_attributes < 2:
-            self.assertEqual(self.widget.cbx.count(), 0)
-            self.assertEqual(self.widget.cby.count(), 0)
-        else:
-            self.assertEqual(self.widget.cbx.count(), num_continuous_attributes)
-            self.assertEqual(self.widget.cby.count(), num_continuous_attributes)
+        assert not np.all(centroids0 == centroids1)
+        w.send_data = Mock()
+        w._update_buttons = Mock()
 
-    def test_autoplay(self):
+        w.step_back()
+        w.send_data.assert_called()
+        w._update_buttons.assert_called()
+        w.send_data.reset_mock()
+        w._update_buttons.reset_mock()
+        np.testing.assert_equal(kmeans.centroids, centroids1)
+        np.testing.assert_equal(kmeans.clusters, clusters1)
+
+        w.step_back()
+        w.send_data.assert_called()
+        w._update_buttons.assert_called()
+        w.send_data.reset_mock()
+        w._update_buttons.reset_mock()
+        np.testing.assert_equal(kmeans.centroids, centroids0)
+        np.testing.assert_equal(kmeans.clusters, clusters0)
+
+    def test_autoplay_buttons(self):
         """
         Check if everything goes correct for autorun
         """
         self.widget.set_data(self.data)
-        self.widget.centroid_numbers_spinner.setValue(4)
+        self.widget.number_of_clusters = 4
 
         # start autoplay
         self.widget.auto_play_button.click()
 
         self.assertEqual(self.widget.variables_box.isEnabled(), False)
-        self.assertEqual(self.widget.centroids_box.isEnabled(), False)
+        self.assertEqual(self.widget.restart_button.isEnabled(), False)
         self.assertEqual(self.widget.step_button.isEnabled(), False)
         self.assertEqual(self.widget.step_back_button.isEnabled(), False)
         self.assertEqual(self.widget.auto_play_button.isEnabled(), True)
-        self.assertEqual(self.widget.auto_play_button.text(),
-                         self.widget.AUTOPLAY_BUTTONS[1])
+        self.assertEqual(self.widget.auto_play_button.text(), "Stop")
 
         # stop autoplay
         self.widget.auto_play_button.click()
 
         self.assertEqual(self.widget.variables_box.isEnabled(), True)
-        self.assertEqual(self.widget.centroids_box.isEnabled(), True)
+        self.assertEqual(self.widget.restart_button.isEnabled(), True)
         self.assertEqual(self.widget.step_button.isEnabled(), True)
         self.assertEqual(self.widget.auto_play_button.isEnabled(), True)
-        self.assertEqual(self.widget.auto_play_button.text(),
-                         self.widget.AUTOPLAY_BUTTONS[0])
+        self.assertNotEqual(self.widget.auto_play_button.text(), "Stop")
 
     def test_centroids_change(self):
-        """
-        Test if number of centroid in k-means changes correctly when adding,
-        deleting centroids
-        """
+        self.widget.number_of_clusters = 4
         self.widget.set_data(self.data)
-        self.widget.centroid_numbers_spinner.setValue(4)
         self.assertEqual(self.widget.k_means.k, 4)
+        self.assertEqual(self.widget.number_of_clusters, 4)
+        np.testing.assert_equal(self.widget.color_map, [0, 1, 2, 3])
 
-        self.widget.centroid_numbers_spinner.setValue(5)
-        self.assertEqual(self.widget.k_means.k, 5)
+        self.widget.on_centroid_clicked(1)
+        self.assertEqual(self.widget.number_of_clusters, 3)
+        np.testing.assert_equal(self.widget.color_map, [0, 2, 3])
 
-        self.widget.centroid_numbers_spinner.setValue(3)
-        self.assertEqual(self.widget.k_means.k, 3)
+        self.widget.on_centroid_add(2, 3)
+        self.assertEqual(self.widget.number_of_clusters, 4)
+        np.testing.assert_equal(self.widget.color_map, [0, 2, 3, 1])
 
-        self.widget.centroid_dropped(0, 1, 1)
-        self.assertEqual(self.widget.k_means.k, 3)
+    def test_no_data(self):
+        self.widget.set_data(None)
+        self.assertIsNone(self.widget.data)
+        self.assertIsNone(self.widget.reduced_data)
+        self.assertIsNone(self.widget.k_means)
+        self.assertEqual(self.widget.var_model.rowCount(), 0)
 
-        self.widget.graph_clicked(1, 1)
-        self.assertEqual(self.widget.k_means.k, 4)
+        # too few continuous attributes: don't create reduced data and k-means
+        domain = Domain(self.data.domain.attributes[:1],
+                        self.data.domain.class_var)
+        data1 = Table.from_table(domain, self.data)
+        self.widget.set_data(data1)
+        self.assertIsNone(self.widget.reduced_data)
+        self.assertIsNone(self.widget.k_means)
+        self.assertEqual(self.widget.var_model.rowCount(), 1)
 
-    def test_step_back(self):
-        """
-        Test if step back restore same positions
-        """
-        self.widget.set_data(self.data)
-        self.widget.centroid_numbers_spinner.setValue(4)
-        before_centroids = np.copy(self.widget.k_means.centroids)
-        before_clusters = np.copy(self.widget.k_means.clusters)
-        self.widget.step_button.click()
-        self.widget.step_back_button.click()
-        after_centroids = np.copy(self.widget.k_means.centroids)
-        after_clusters = np.copy(self.widget.k_means.clusters)
-
-        np.testing.assert_equal(before_centroids, after_centroids)
-        np.testing.assert_equal(before_clusters, after_clusters)
-
-        # few click deeper
-        self.widget.step_button.click()
-        self.widget.step_button.click()
-        self.widget.step_button.click()
-        self.widget.step_button.click()
-        self.widget.step_button.click()
-        self.widget.step_back_button.click()
-        self.widget.step_back_button.click()
-        self.widget.step_back_button.click()
-        self.widget.step_back_button.click()
-        self.widget.step_back_button.click()
-        after_centroids = np.copy(self.widget.k_means.centroids)
-        after_clusters = np.copy(self.widget.k_means.clusters)
-
-        np.testing.assert_equal(before_centroids, after_centroids)
-        np.testing.assert_equal(before_clusters, after_clusters)
+    def test_data_no_non_nan_data(self):
+        self.dataxy[:5, 0] = np.nan
+        self.dataxy[5:, 1] = np.nan
+        self.send_signal(self.widget.Inputs.data, self.dataxy)
+        self.assertIsNone(self.widget.reduced_data)
+        self.assertIsNone(self.widget.k_means)
 
     def test_restart(self):
         self.widget.set_data(self.data)
-        kmeans_before = self.widget.k_means
+        prev_centroids = self.widget.k_means.centroids
         self.widget.restart_button.click()
-
-        # check if instantiated new k-means
-        self.assertNotEqual(self.widget.k_means, kmeans_before)
-        self.assertEqual(self.widget.k_means.step_no, 0)
-        self.assertEqual(self.widget.k_means.k, self.widget.number_of_clusters)
-
-    def test_button_text_change(self):
-        self.widget.set_data(self.data)
-        self.widget.centroid_numbers_spinner.setValue(4)
-        self.widget.button_text_change()
-        self.assertEqual(self.widget.step_button.text(),
-                         self.widget.STEP_BUTTONS[1])
-        self.assertEqual(self.widget.step_back_button.isEnabled(), False)
-
-        self.widget.step_button.click()
-        self.widget.button_text_change()
-        self.assertEqual(self.widget.step_button.text(),
-                         self.widget.STEP_BUTTONS[0])
-        self.assertEqual(self.widget.step_back_button.isEnabled(), True)
-
-        self.widget.auto_play_button.click()
-        self.widget.button_text_change()
-        self.assertEqual(self.widget.step_back_button.isEnabled(), False)
-        self.widget.auto_play_button.click()  # stop autoplay
-        self.widget.button_text_change()
-        self.assertEqual(self.widget.step_back_button.isEnabled(), True)
-
-    def test_replot(self):
-        self.widget.replot()
-        # 1 because graph cleaned on the beginning
-        self.assertEqual(self.widget.scatter.count_replots, 1)
-        self.widget.set_data(self.data)
-        self.assertEqual(self.widget.scatter.count_replots, 2)
-        self.widget.step_button.click()
-        self.assertEqual(self.widget.scatter.count_replots, 2)
-        # still 2 because just centroids moved not complete replot
-
-        self.widget.lines_checkbox.nextCheckState()
-        self.assertEqual(self.widget.scatter.count_replots, 3)
-
-        self.widget.step_button.click()
-        self.assertEqual(self.widget.scatter.count_replots, 4)
-        # complete replot because it is cluster change
-
-        self.widget.step_button.click()
-        self.assertEqual(self.widget.scatter.count_replots, 4)
-        # just move centroids
-
-    def test_number_of_clusters_change(self):
-        # provide less data than clusters to check
-        # if k-menas initiated after that
-        self.widget.centroid_numbers_spinner.setValue(5)
-        self.widget.set_data(self.data[:3])
-        self.widget.centroid_numbers_spinner.setValue(1)
-        self.assertNotEqual(self.widget.k_means, None)
-
-        self.widget.set_data(self.data)
-        self.assertEqual(self.widget.k_means.k, self.widget.number_of_clusters)
-        self.widget.centroid_numbers_spinner.setValue(1)
-        # ok if number of clusters unchanged
-        self.assertEqual(self.widget.k_means.k, self.widget.number_of_clusters)
-        self.widget.centroid_numbers_spinner.setValue(5)
-        self.assertEqual(self.widget.k_means.k, self.widget.number_of_clusters)
-        self.widget.centroid_numbers_spinner.setValue(3)
-        self.assertEqual(self.widget.k_means.k, self.widget.number_of_clusters)
-
-    def test_send_data(self):
-        self.widget.send_data()
-        # some test will be added after output check enabled in testGui
-
-    def test_replot_series(self):
-        self.widget.set_data(self.data)
-        self.assertEqual(self.widget.scatter.count_replots, 2)
-        self.widget.replot_series()
-        self.assertEqual(self.widget.scatter.count_replots, 2)
-        # still 2 because just centroids moved not complete replot
-
-        self.widget.replot_series()
-        self.assertEqual(self.widget.scatter.count_replots, 2)
-
-        self.widget.lines_checkbox.nextCheckState()
-        self.widget.replot_series()
-        self.assertEqual(self.widget.scatter.count_replots, 3)
-        # 3 because of nextState
-
-        self.widget.replot_series()
-        self.assertEqual(self.widget.scatter.count_replots, 3)
-
-    def test_scatter_chart_clicked(self):
-        self.widget.set_data(self.data)
-        self.widget.centroid_numbers_spinner.setValue(1)
-        self.widget.scatter.bridge.chart_clicked(1, 2)
-
-        self.assertEqual(self.widget.k_means.k, 2)
-
-        self.widget.set_data(None)
-        self.widget.scatter.bridge.chart_clicked(1, 2)
-        self.assertEqual(self.widget.k_means.k, 2)  # no changes when no data
-
-    def test_scatter_point_dropped(self):
-        self.widget.set_data(self.data)
-        self.widget.centroid_numbers_spinner.setValue(1)
-        self.widget.scatter.bridge.point_dropped(0, 1, 2)
-
-        self.assertEqual(self.widget.k_means.k, 1)
-
-        self.assertEqual(self.widget.k_means.centroids[0].tolist(), [1, 2])
+        self.assertFalse(np.all(prev_centroids - self.widget.k_means.centroids == 0))
 
     def test_send_report(self):
-        """
-        Just test report not crashes
-        """
         w = self.widget
-
         w.set_data(self.data)
-        w.centroid_numbers_spinner.setValue(3)
-        self.process_events(lambda: w.scatter.svg())
         w.report_button.click()
-
-        self.assertIn("Number of centroids", w.report_html)
-
-        # if no data
-        w.set_data(None)
-        w.report_button.click()
-
-        self.assertNotIn("Number of centroids", w.report_html)
-
-    def test_data_nan_column(self):
-        """
-        Do not crash when a column has a nan value.
-        GH-40
-        """
-        data = self.data
-        domain = Domain(attributes=data.domain.attributes[:2], class_vars=data.domain.class_vars)
-        data = data.transform(domain)
-        data[:, 0] = np.nan
-        self.send_signal(self.widget.Inputs.data, data)
 
 
 if __name__ == "__main__":
-    import unittest
     unittest.main()

--- a/orangecontrib/educational/widgets/tests/test_owkmeans.py
+++ b/orangecontrib/educational/widgets/tests/test_owkmeans.py
@@ -49,14 +49,14 @@ class TestOWKmeans(WidgetTest):
 
         # none input
         self.widget.set_data(None)
-        self.assertEqual(self.widget.options_box.isEnabled(), False)
+        self.assertEqual(self.widget.variables_box.isEnabled(), False)
         self.assertEqual(self.widget.centroids_box.isEnabled(), False)
         self.assertEqual(self.widget.step_box.isEnabled(), False)
         self.assertEqual(self.widget.run_box.isEnabled(), False)
 
         # if data provided
         self.widget.set_data(self.data)
-        self.assertEqual(self.widget.options_box.isEnabled(), True)
+        self.assertEqual(self.widget.variables_box.isEnabled(), True)
         self.assertEqual(self.widget.centroids_box.isEnabled(), True)
         self.assertEqual(self.widget.step_box.isEnabled(), True)
         self.assertEqual(self.widget.run_box.isEnabled(), True)
@@ -66,7 +66,7 @@ class TestOWKmeans(WidgetTest):
                                     self.data.domain.class_var)
         data1 = Orange.data.Table.from_table(domain, self.data)
         self.widget.set_data(data1)
-        self.assertEqual(self.widget.options_box.isEnabled(), False)
+        self.assertEqual(self.widget.variables_box.isEnabled(), False)
         self.assertEqual(self.widget.centroids_box.isEnabled(), False)
         self.assertEqual(self.widget.step_box.isEnabled(), False)
         self.assertEqual(self.widget.run_box.isEnabled(), False)
@@ -74,7 +74,7 @@ class TestOWKmeans(WidgetTest):
         # if too much clusters for data
         self.widget.number_of_clusters = 3
         self.widget.set_data(self.data[:2])
-        self.assertEqual(self.widget.options_box.isEnabled(), True)
+        self.assertEqual(self.widget.variables_box.isEnabled(), True)
         self.assertEqual(self.widget.centroids_box.isEnabled(), True)
         self.assertEqual(self.widget.step_box.isEnabled(), False)
         self.assertEqual(self.widget.run_box.isEnabled(), False)
@@ -122,7 +122,7 @@ class TestOWKmeans(WidgetTest):
         # start autoplay
         self.widget.auto_play_button.click()
 
-        self.assertEqual(self.widget.options_box.isEnabled(), False)
+        self.assertEqual(self.widget.variables_box.isEnabled(), False)
         self.assertEqual(self.widget.centroids_box.isEnabled(), False)
         self.assertEqual(self.widget.step_button.isEnabled(), False)
         self.assertEqual(self.widget.step_back_button.isEnabled(), False)
@@ -133,7 +133,7 @@ class TestOWKmeans(WidgetTest):
         # stop autoplay
         self.widget.auto_play_button.click()
 
-        self.assertEqual(self.widget.options_box.isEnabled(), True)
+        self.assertEqual(self.widget.variables_box.isEnabled(), True)
         self.assertEqual(self.widget.centroids_box.isEnabled(), True)
         self.assertEqual(self.widget.step_button.isEnabled(), True)
         self.assertEqual(self.widget.auto_play_button.isEnabled(), True)

--- a/orangecontrib/educational/widgets/utils/kmeans.py
+++ b/orangecontrib/educational/widgets/utils/kmeans.py
@@ -180,6 +180,14 @@ class Kmeans:
             self.centroids = np.vstack((self.centroids, np.array(points)))
         self.recompute_clusters()
 
+    def delete_centroid(self, num):
+        """
+        Remove a centroid
+        """
+        self.centroids = np.vstack((self.centroids[:num],
+                                    self.centroids[num + 1:]))
+        self.recompute_clusters()
+
     def delete_centroids(self, num):
         """
         Remove last num centroids

--- a/orangecontrib/educational/widgets/utils/kmeans.py
+++ b/orangecontrib/educational/widgets/utils/kmeans.py
@@ -1,6 +1,29 @@
-import Orange
+from functools import wraps
+from types import FunctionType
+from typing import NamedTuple, List
+
 import numpy as np
-from Orange.distance import Euclidean
+
+import Orange
+
+
+HistoryEntry = NamedTuple("HistoryEntry", (("step", FunctionType),
+                                           ("centroids", np.ndarray),
+                                           ("clusters", np.ndarray)))
+
+
+def historic(reassign=True):
+    def decorator(f):
+        @wraps(f)
+        def historian(self, *args, **kwargs):
+            # store decorated function (not `f`) to enable comparisons with
+            # Kmeans.<whatever>
+            self._store_history(historian)
+            f(self, *args, **kwargs)
+            if reassign:
+                self.clusters = self._find_clusters()
+        return historian
+    return decorator if isinstance(reassign, bool) else decorator(reassign)
 
 
 class Kmeans:
@@ -16,199 +39,84 @@ class Kmeans:
     distance_metric: Orange.distance
         Distance used to measure distance to point in k-means
     """
-
-    max_iter = 100
-    threshold = 1e-1
-
     def __init__(self, data,
                  centroids=None, distance_metric=Orange.distance.Euclidean):
-        self.data = data
-        self.centroids = (np.array(centroids)
-                          if centroids is not None else np.empty((0, 2)))
+        self.data = None
+        self.centroids = None
         self.distance_metric = distance_metric
-        self.step_no = 0
-        self.clusters = self.find_clusters(self.centroids)
-        self.centroids_history = [np.copy(self.centroids)]
-        self.centroids_moved = False
+        self.history: List[HistoryEntry] = []
+        self.clusters = None
+        if data is not None:
+            self.reset(data, centroids)
 
     @property
     def k(self):
-        return len(self.centroids) if self.centroids is not None else 0
+        return len(self.centroids)
 
     @property
-    def centroids_belonging_points(self):
-        d = self.data.X
-        return [d[self.clusters == i] for i in range(len(self.centroids))]
+    def waits_reassignment(self):
+        return self.history and self.history[-1].step == Kmeans.move_centroids
 
     @property
     def converged(self):
         """
-        Function check if algorithm already converged
+        Clustering converged if the last three steps were assignment, moving,
+        and assignment, with membership assignments being the same.
         """
-        if len(self.centroids_history) <= 1 or \
-                (len(self.centroids) != len(self.centroids_history[self.step_no - 2])) or \
-                not self.step_completed:
+        if len(self.history) < 3:
             return False
-        dist = (np.sum(
-            np.sqrt(np.sum(
-                np.power(
-                    (self.centroids - self.centroids_history[self.step_no - 2]),
-                    2),
-                axis=1))) / len(self.centroids))
+        a, b, c = self.history[-3:]
+        return a.step == c.step == Kmeans.assign_membership \
+               and b.step == Kmeans.move_centroids \
+               and np.all(a.clusters == c.clusters)
 
-        return dist < self.threshold or self.step_no > self.max_iter
+    def _find_clusters(self):
+        dist = self.distance_metric(self.data.X, self.centroids)
+        return np.argmin(dist, axis=1)
 
-    @property
-    def step_completed(self):
-        return self.step_no % 2 == 0
-
-    def set_data(self, data):
-        """
-        Function called when data changed on input
-
-        Parameters
-        ----------
-        data : Orange.data.Table or None
-            Data used for k-means
-        """
-        self.__init__(data, self.centroids, distance_metric=self.distance_metric)
-
-    def find_clusters(self, centroids):
-        """
-        Function calculates new clusters to data points
-        """
-        if self.k > 0:
-            d = self.data.X
-            dist = self.distance_metric(d, centroids)
-            return np.argmin(dist, axis=1)
-        else:
-            return None
-
-    def step(self):
-        """
-        Half of the step of k-means
-        """
-        if self.step_completed:
-            d = self.data.X
-            points = [d[self.clusters == i] for i in range(len(self.centroids))]
-            for i in range(len(self.centroids)):
-                c_points = points[i]
-                self.centroids[i, :] = (np.average(c_points, axis=0)
-                                        if len(c_points) > 0 else np.nan)
-            # reinitialize empty centroids
-
-            nan_c = np.isnan(self.centroids).any(axis=1)
-            if np.count_nonzero(nan_c) > 0:
-                self.centroids[nan_c] = self.random_positioning(
-                    np.count_nonzero(nan_c))
-            self.centroids_moved = True
-        else:
-            self.clusters = self.find_clusters(self.centroids)
-            self.centroids_moved = False
-        self.step_no += 1
-        self.centroids_history = self.set_list(
-            self.centroids_history, self.step_no, np.copy(self.centroids))
+    def _store_history(self, step):
+        self.history.append(
+            HistoryEntry(step, np.copy(self.centroids), np.copy(self.clusters)))
 
     def step_back(self):
-        """
-        Half of the step back of k-means
-        """
-        if self.step_no > 0:
-            if not self.step_completed:
-                self.centroids = np.copy(
-                    self.centroids_history[self.step_no - 1])
-                self.centroids_moved = True
-            else:
-                self.centroids = np.copy(
-                    self.centroids_history[self.step_no - 1])
-                self.clusters = self.find_clusters(
-                    self.centroids_history[self.step_no - 2])
-                self.centroids_moved = False
-            self.step_no -= 1
+        if self.history:
+            _, self.centroids, self.clusters = self.history.pop()
 
-    def random_positioning(self, no_centroids):
-        """
-        Calculates new centroid using random positioning
+    def reset(self, data, centroids=3):
+        self.data = data
+        self.centroids = np.array(
+                centroids if not isinstance(centroids, int)
+                else [self._random_position() for _ in range(centroids)])
+        self.clusters = self._find_clusters()
+        self.history = []
 
-        Parameters
-        ----------
-        no_centroids : int
-            number of centroids to calculate
+    @historic
+    def assign_membership(self):
+        pass
 
-        Returns
-        -------
-        np.array
-            new centroid
-        """
-        if no_centroids <= 0:
-            return np.array([])
-        centroids = np.empty((no_centroids, 2))
-        for i in range(no_centroids):
-            idx = np.random.choice(
-                len(self.data), np.random.randint(
-                    1, np.min((5, len(self.data) + 1))))
-            centroids[i, :] = np.mean(self.data.X[idx], axis=0)
-        return centroids
+    @historic(reassign=False)
+    def move_centroids(self):
+        d = self.data.X
+        for i in range(self.k):
+            points = d[self.clusters == i]
+            self.centroids[i, :] = np.average(points, axis=0) if points.size \
+                                   else self._random_position()
 
-    def recompute_clusters(self):
-        """
-        Function recomputes belonging points to centroid and increases step_no
-        """
-        self.clusters = self.find_clusters(self.centroids)
-        self.centroids_moved = False
-        if not self.step_completed:
-            self.step_no += 1
-        self.centroids_history = self.set_list(
-            self.centroids_history, self.step_no, np.copy(self.centroids))
+    @historic
+    def add_centroid(self, x=None, y=None):
+        assert (x is None) == (y is None)
+        new = self._random_position() if x is None else np.array([x, y])
+        self.centroids = np.vstack((self.centroids, new))
 
-    def add_centroids(self, points=None):
-        """
-        Add new centroid/s. Using points if provided else random positioning
-
-        Parameters
-        ----------
-        points : list or numpy.array or int or None
-            Centroids or number of them
-        """
-        if points is None:  # if no point provided add one centroid
-            self.centroids = np.vstack(
-                (self.centroids, self.random_positioning(1)))
-        elif isinstance(points, int):  # if int provided add as much of them
-            self.centroids = np.vstack(
-                (self.centroids, self.random_positioning(points)))
-        else:   # else it is array of new centroids
-            self.centroids = np.vstack((self.centroids, np.array(points)))
-        self.recompute_clusters()
-
+    @historic
     def delete_centroid(self, num):
-        """
-        Remove a centroid
-        """
         self.centroids = np.vstack((self.centroids[:num],
                                     self.centroids[num + 1:]))
-        self.recompute_clusters()
 
-    def delete_centroids(self, num):
-        """
-        Remove last num centroids
-        """
-        self.centroids = self.centroids[:(-num if num <= len(self.centroids)
-                                          else len(self.centroids))]
-        self.recompute_clusters()
-
+    @historic
     def move_centroid(self, _index, x, y):
-        """
-        Move centroid with index to position x, y
-        """
         self.centroids[_index, :] = np.array([x, y])
-        self.centroids_moved = False
-        self.recompute_clusters()
 
-    @staticmethod
-    def set_list(l, i, v):
-        try:
-            l[i] = v
-        except IndexError:
-            assert i == len(l)
-            l.append(v)
-        return l
+    def _random_position(self):
+        sample = np.random.choice(len(self.data), np.min((5, len(self.data))))
+        return np.mean(self.data.X[sample], axis=0)

--- a/orangecontrib/educational/widgets/utils/kmeans.py
+++ b/orangecontrib/educational/widgets/utils/kmeans.py
@@ -40,8 +40,7 @@ class Kmeans:
         self.centroids = None
         self.history: List[HistoryEntry] = []
         self.clusters = None
-        if data is not None:
-            self.reset(data, centroids)
+        self.reset(data, centroids)
 
     @property
     def k(self):

--- a/orangecontrib/educational/widgets/utils/kmeans.py
+++ b/orangecontrib/educational/widgets/utils/kmeans.py
@@ -32,18 +32,12 @@ class Kmeans:
 
     Parameters
     ----------
-    data: Orange.data.Table
-        Data used for k-means
-    centroids: list or numpy.array
-        List of centroids
-    distance_metric: Orange.distance
-        Distance used to measure distance to point in k-means
+    data (np.ndarray): two-column d ata used for k-means
+    centroids (int, list or numpy.array or int): number of coordinates of centroids
     """
-    def __init__(self, data,
-                 centroids=None, distance_metric=Orange.distance.Euclidean):
+    def __init__(self, data, centroids=3):
         self.data = None
         self.centroids = None
-        self.distance_metric = distance_metric
         self.history: List[HistoryEntry] = []
         self.clusters = None
         if data is not None:
@@ -71,7 +65,7 @@ class Kmeans:
                and np.all(a.clusters == c.clusters)
 
     def _find_clusters(self):
-        dist = self.distance_metric(self.data.X, self.centroids)
+        dist = Orange.distance.Euclidean(self.data, self.centroids)
         return np.argmin(dist, axis=1)
 
     def _store_history(self, step):
@@ -96,9 +90,8 @@ class Kmeans:
 
     @historic(reassign=False)
     def move_centroids(self):
-        d = self.data.X
         for i in range(self.k):
-            points = d[self.clusters == i]
+            points = self.data[self.clusters == i]
             self.centroids[i, :] = np.average(points, axis=0) if points.size \
                                    else self._random_position()
 
@@ -118,5 +111,6 @@ class Kmeans:
         self.centroids[_index, :] = np.array([x, y])
 
     def _random_position(self):
-        sample = np.random.choice(len(self.data), np.min((5, len(self.data))))
-        return np.mean(self.data.X[sample], axis=0)
+        n = len(self.data)
+        sample = np.random.choice(n, np.min((5, n)))
+        return np.mean(self.data[sample], axis=0)

--- a/orangecontrib/educational/widgets/utils/tests/test_kmeans.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_kmeans.py
@@ -1,206 +1,112 @@
 import unittest
-from Orange.data import Table, Domain
+
 from orangecontrib.educational.widgets.utils.kmeans import Kmeans
 import numpy as np
 
 
 class TestKmeans(unittest.TestCase):
-
     def setUp(self):
-        self.data = Table('iris')
-        new_domain = Domain(self.data.domain.attributes[:2])
-        self.data = Table.from_table(new_domain, self.data)
-        # self.centroids = [[5.2, 3.1], [6.5, 3], [7, 4]]
+        self.data = np.arange(20).reshape(10, 2)
         self.kmeans = Kmeans(self.data)
 
-    def test_k(self):
-        centroids = [[5.2, 3.1], [6.5, 3], [7, 4]]
-        self.kmeans.add_centroids(centroids)
-        self.assertEqual(self.kmeans.k, 3)
-        self.assertEqual(self.kmeans.k, len(self.kmeans.centroids))
-
     def test_converged(self):
-        centroids = [[5.2, 3.1], [6.5, 3], [7, 4]]
-        self.kmeans.add_centroids(centroids)
-        self.assertFalse(self.kmeans.converged)
-
-        self.kmeans.step()
-        self.assertFalse(self.kmeans.converged)
-        # step not complete so false every odd state
-
-        self.kmeans.step()
-        # it is even step so maybe converged but it depends on example
-        # unable to test
-        self.kmeans.step()
-        self.assertFalse(self.kmeans.converged)
-
-        # check if false every not completed step
-        for i in range(self.kmeans.max_iter // 2 + 1):
-            self.kmeans.step()
-            self.kmeans.step()
-            self.assertFalse(self.kmeans.converged)
-
-        # it converged because of max iter
-        self.kmeans.step()
+        """It doesn't converge in a half-step, but does eventually"""
+        i = -1
+        for i in range(50):
+            self.kmeans.move_centroids()
+            self.kmeans.assign_membership()
+            if self.kmeans.converged:
+                break
+        self.assertGreater(i, 1)
         self.assertTrue(self.kmeans.converged)
 
-    def test_centroids_belonging_points(self):
-        centroids = [[5.2, 3.6]]
-        self.kmeans.add_centroids(centroids)
+    def test_reset(self):
+        assert self.kmeans.k == len(self.kmeans.centroids) == 3
+        centroids = self.kmeans.centroids.copy()
+        self.kmeans.reset(self.data[:9])
+        np.testing.assert_equal(self.kmeans.data, self.data[:9])
+        self.assertFalse(np.all(centroids == self.kmeans.centroids.copy()))
 
-        # if only one cluster all points in 0th element of first dimension
-        np.testing.assert_equal(
-            self.kmeans.centroids_belonging_points, np.array([self.data.X]))
-
-        # try with two clusters and less data
-        self.kmeans.set_data(self.data[:3])
-        self.kmeans.add_centroids([[4.7, 3.0]])
-        desired_array = np.array([np.array([[5.100, 3.500]]),
-                                  np.array([[4.900, 3.000],
-                                            [4.700, 3.200]])])
-        for i, arr in enumerate(self.kmeans.centroids_belonging_points):
-            np.testing.assert_equal(arr, desired_array[i])
-
-    def test_step_completed(self):
-        centroids = [[5.2, 3.1], [6.5, 3], [7, 4]]
-        self.kmeans.add_centroids(centroids)
-        self.assertEqual(self.kmeans.step_completed, True)
-        self.kmeans.step()
-        self.assertEqual(self.kmeans.step_completed, False)
-        self.kmeans.step()
-        self.assertEqual(self.kmeans.step_completed, True)
-
-    def test_set_data(self):
-        self.kmeans.set_data(self.data)
-        self.assertEqual(self.kmeans.data, self.data)
-        self.assertEqual(self.kmeans.centroids_history[0].size, 0)
-        self.assertEqual(self.kmeans.step_no, 0)
-        self.assertEqual(self.kmeans.step_completed, True)
-        self.assertEqual(self.kmeans.centroids_moved, False)
-
-        # try with none data
-        self.kmeans.set_data(None)
-        self.assertEqual(self.kmeans.data, None)
-        self.assertEqual(self.kmeans.centroids_history[0].size, 0)
-        self.assertEqual(self.kmeans.clusters, None)
-        self.assertEqual(self.kmeans.step_no, 0)
-        self.assertEqual(self.kmeans.step_completed, True)
-        self.assertEqual(self.kmeans.centroids_moved, False)
+        self.kmeans.reset(self.data, 5)
+        np.testing.assert_equal(self.kmeans.data, self.data)
+        self.assertEqual(self.kmeans.k, 5)
 
     def test_find_clusters(self):
-        self.kmeans.add_centroids([[5.2, 3.6]])
+        # if there is only one cluster, all points belong to it
+        self.kmeans.reset(self.data, 1)
+        np.testing.assert_equal(self.kmeans._find_clusters(), 0)
 
-        # if only one cluster all points in 0th element of first dimension
-        np.testing.assert_equal(
-            self.kmeans.find_clusters(self.kmeans.centroids),
-            np.zeros(len(self.data)))
+        # Have two centroids that split the data
+        self.kmeans.reset(self.data, 2)
+        self.kmeans.move_centroid(1, 4, 5)
+        self.kmeans.move_centroid(0, 6, 7)
+        np.testing.assert_equal(self.kmeans._find_clusters(), [1] * 3 + [0] * 7)
 
-        # try with two clusters and less data
-        self.kmeans.set_data(self.data[:3])
-        self.kmeans.add_centroids([[4.7, 3.0]])
-        np.testing.assert_equal(
-            self.kmeans.find_clusters(self.kmeans.centroids),
-            np.array([0, 1, 1]))
+    def test_steps(self):
+        self.kmeans.reset(self.data, 2)
+        self.kmeans.centroids = np.array([[6, 7], [4, 5]])
+        self.kmeans.assign_membership()
+        np.testing.assert_equal(self.kmeans.clusters, [1] * 3 + [0] * 7)
 
-    def test_step(self):
-        centroids = [[5.2, 3.1], [6.5, 3], [7, 4]]
-        self.kmeans.add_centroids(centroids)
-        centroids_before = np.copy(self.kmeans.centroids)
-        clusters_before = np.copy(self.kmeans.clusters)
-        self.kmeans.step()
-        self.assertEqual(self.kmeans.step_completed, False)
-        self.assertEqual(self.kmeans.centroids_moved, True)
-        np.testing.assert_equal(centroids_before,
-                                self.kmeans.centroids_history[-2])
-        # clusters doesnt change in every odd step
-        np.testing.assert_equal(clusters_before, self.kmeans.clusters)
+        self.kmeans.move_centroids()
+        np.testing.assert_equal(self.kmeans.centroids, [[12, 13], [2, 3]])
 
-        centroids_before = np.copy(self.kmeans.centroids)
-        self.kmeans.step()
-        self.assertEqual(self.kmeans.step_completed, True)
-        self.assertEqual(self.kmeans.centroids_moved, False)
-        np.testing.assert_equal(centroids_before, self.kmeans.centroids)
+    def test_history(self):
+        assert not self.kmeans.history
 
-        centroids_before = np.copy(self.kmeans.centroids)
-        self.kmeans.step()
+        centroids = self.kmeans.centroids.copy()
+        self.kmeans.move_centroids()
+        self.assertIs(self.kmeans.history[0].step, Kmeans.move_centroids)
+
+        clusters = self.kmeans.clusters.copy()
+        self.kmeans.assign_membership()
+        self.assertIs(self.kmeans.history[1].step, Kmeans.assign_membership)
+
+        self.assertEqual(len(self.kmeans.history), 2)
+
         self.kmeans.step_back()
-        np.testing.assert_equal(centroids_before, self.kmeans.centroids)
+        self.assertEqual(len(self.kmeans.history), 1)
+        self.assertIs(self.kmeans.history[0].step, Kmeans.move_centroids)
+        np.testing.assert_equal(self.kmeans.clusters, clusters)
 
-    def test_step_back(self):
-        centroids = [[5.2, 3.1], [6.5, 3], [7, 4]]
-        self.kmeans.add_centroids(centroids)
-
-        # check if nothing happens when step = 0
-        centroids_before = np.copy(self.kmeans.centroids)
-        clusters_before = np.copy(self.kmeans.clusters)
         self.kmeans.step_back()
-        np.testing.assert_equal(centroids_before, self.kmeans.centroids)
-        np.testing.assert_equal(clusters_before, self.kmeans.clusters)
+        self.assertEqual(len(self.kmeans.history), 0)
+        np.testing.assert_equal(self.kmeans.centroids, centroids)
 
-        # check if centroids remain in even step
-        self.kmeans.step()
-        self.kmeans.step()
+    def test_add_centroid(self):
+        centroids = self.kmeans.centroids.tolist()
+        assert len(centroids) == 3
+        self.kmeans.add_centroid(4, 5)
+        self.assertEqual(self.kmeans.k, 4)
+        self.assertEqual(self.kmeans.centroids.tolist(), centroids + [[4, 5]])
+        self.assertIs(self.kmeans.history[-1].step, Kmeans.add_centroid)
 
-        centroids_before = self.kmeans.centroids
         self.kmeans.step_back()
-        np.testing.assert_equal(centroids_before, self.kmeans.centroids)
-        self.assertEqual(self.kmeans.step_completed, False)
-        self.assertEqual(self.kmeans.centroids_moved, False)
+        self.assertEqual(self.kmeans.centroids.tolist(), centroids)
 
-        # check if clusters remain in even step
-        clusters_before = self.kmeans.clusters
-        self.kmeans.step_back()
-        np.testing.assert_equal(clusters_before, self.kmeans.clusters)
-        self.assertEqual(self.kmeans.step_completed, True)
-        self.assertEqual(self.kmeans.centroids_moved, True)
-
-    def test_random_positioning(self):
-        self.assertEqual(self.kmeans.random_positioning(4).shape, (4, 2))
-        self.assertEqual(self.kmeans.random_positioning(1).shape, (1, 2))
-        self.assertEqual(self.kmeans.random_positioning(0).shape, (0,))
-        self.assertEqual(self.kmeans.random_positioning(-1).shape, (0,))
-
-    def test_add_centroids(self):
-        self.kmeans.add_centroids([[5.2, 3.1]])
-        self.assertEqual(self.kmeans.k, 1)
-        self.kmeans.add_centroids([[6.5, 3], [7, 4]])
-        self.assertEqual(self.kmeans.k, 3)
-        self.kmeans.add_centroids(2)
-        self.assertEqual(self.kmeans.k, 5)
-        self.kmeans.add_centroids()
-        self.assertEqual(self.kmeans.k, 6)
-
-        step_before = self.kmeans.step_no
-        self.assertEqual(step_before, self.kmeans.step_no)
-        self.kmeans.step()
-        self.kmeans.add_centroids()
-        self.assertEqual(step_before + 2, self.kmeans.step_no)
-        self.assertEqual(self.kmeans.centroids_moved, False)
-
-    def test_delete_centroids(self):
-        self.kmeans.add_centroids([[6.5, 3], [7, 4], [5.2, 3.1]])
-        self.kmeans.delete_centroids(1)
+    def test_delete_centroid(self):
+        centroids = self.kmeans.centroids.tolist()
+        assert len(centroids) == 3
+        self.kmeans.delete_centroid(1)
         self.assertEqual(self.kmeans.k, 2)
-        self.kmeans.delete_centroids(2)
-        self.assertEqual(self.kmeans.k, 0)
-        self.kmeans.delete_centroids(2)
-        self.assertEqual(self.kmeans.k, 0)
+        self.assertEqual(self.kmeans.centroids.tolist(),
+                         centroids[:1] + centroids[2:])
+        self.assertIs(self.kmeans.history[-1].step, Kmeans.delete_centroid)
+
+        self.kmeans.step_back()
+        self.assertEqual(self.kmeans.centroids.tolist(), centroids)
 
     def test_move_centroid(self):
-        self.kmeans.add_centroids([[6.5, 3], [7, 4], [5.2, 3.1]])
-        self.kmeans.move_centroid(1, 3, 3.2)
-        np.testing.assert_equal(self.kmeans.centroids[1], np.array([3, 3.2]))
+        c0, c1, c2 = self.kmeans.centroids.tolist()
+        cn = [3, 3.2]
+        self.kmeans.move_centroid(1, *cn)
+        self.assertEqual(self.kmeans.centroids.tolist(), [c0, cn, c2])
         self.assertEqual(self.kmeans.k, 3)
+        self.assertIs(self.kmeans.history[-1].step, Kmeans.move_centroid)
 
-        self.kmeans.step()
-        self.kmeans.move_centroid(2, 3.2, 3.4)
-        self.assertEqual(self.kmeans.centroids_moved, False)
-        self.assertEqual(self.kmeans.step_no, 2)
+        self.kmeans.step_back()
+        self.assertEqual(self.kmeans.centroids.tolist(), [c0, c1, c2])
 
-    def test_set_list(self):
-        # adding to end
-        self.assertEqual(self.kmeans.set_list([2, 1], 2, 1), [2, 1, 1])
-        # changing the element in the last place
-        self.assertEqual(self.kmeans.set_list([2, 1], 1, 3), [2, 3])
-        # changing the element in the middle place
-        self.assertEqual(self.kmeans.set_list([2, 1, 3], 1, 3), [2, 3, 3])
+
+if __name__ == "__main__":
+    unittest.main()

--- a/orangecontrib/educational/widgets/utils/tests/test_kmeans.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_kmeans.py
@@ -11,6 +11,9 @@ class TestKmeans(unittest.TestCase):
 
     def test_converged(self):
         """It doesn't converge in a half-step, but does eventually"""
+        self.kmeans.move_centroid(0, 0, 1)
+        self.kmeans.move_centroid(1, 2, 3)
+        self.kmeans.move_centroid(2, 4, 5)
         i = -1
         for i in range(50):
             self.kmeans.move_centroids()


### PR DESCRIPTION
##### Issue

K-means depends on highchart. We'd prefer it didn't.

##### Description of changes

Other improvements:
- animate membership reassignment
- use domain model and context settings
- remove centroids by clicking
- UX simplifications - primarily targeting the most common use, that is, with painted data:
  - hide combos with variables when there are only two
  - show attribute names on axes, except when they are named x and y
  - hide axis when there are only two attributes, names x and y and from interaval [0, 1]
  - remove redundant elements (number of clusters, animation speed)
- use Orange's palettes
- prevent user from having more clusters than data points, instead of showing an error
- simplify the underlying kmeans code

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
