### PR TITLE
Gradient Descent: Remove highcharts, other minor improvements

### DIFF
--- a/orangecontrib/educational/widgets/utils/gradient_descent.py
+++ b/orangecontrib/educational/widgets/utils/gradient_descent.py
@@ -89,7 +89,7 @@ class GradientDescent:
         if self.step_no == 0:
             return False
         return (np.sum(np.abs(self.theta - self.history[self.step_no - 1][0])) /
-                len(self.theta) < (1e-2 if not self.stochastic else 1e-5))
+                len(self.theta) < (1e-3 if not self.stochastic else 1e-5))
 
     def step(self):
         """

--- a/orangecontrib/educational/widgets/utils/tests/test_linear_regression.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_linear_regression.py
@@ -75,13 +75,12 @@ class TestLinearRegression(unittest.TestCase):
         self.assertFalse(lr.converged)
 
         # it converge when distance between current theta and this is < 1e-2
-        converge = False
-        while not converge:
+        for _ in range(1500):
             lr.step()
-            converge = (np.sum(
-                np.abs(lr.theta - lr.history[lr.step_no - 1][0])) /
-                        len(lr.theta) < 1e-2)
-            self.assertEqual(lr.converged, converge)
+            if lr.converged:
+                break
+        else:
+            self.fail()
 
     def test_step(self):
         """

--- a/orangecontrib/educational/widgets/utils/tests/test_logistic_regression.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_logistic_regression.py
@@ -66,14 +66,13 @@ class TestLogisticRegression(unittest.TestCase):
         # it can not converge in the first step
         self.assertFalse(lr.converged)
 
-        # it converge when distance between current theta and this is < 1e-2
-        converge = False
-        while not converge:
+        # it converges eventually
+        for _ in range(5000):
             lr.step()
-            converge = (np.sum(
-                np.abs(lr.theta - lr.history[lr.step_no - 1][0])) /
-                        len(lr.theta) < 1e-2)
-            self.assertEqual(lr.converged, converge)
+            if lr.converged:
+                break
+        else:
+            self.fail()
 
     def test_step(self):
         """


### PR DESCRIPTION
##### Issue

Gradient Descent uses highcharts. We'd prefer it didn't.

##### Description of changes

I changed this one less than the other two (k-meand and polynomial classification).
- Replaced highcharts with pyqtgraph
- Simplified GUI (speed is fixed, attr y and target are hidden for regression, buttons are reorganized)
- Mouse cursor changes to crosshair and shows the cost at the hovered point (computed by learner, not from grid)
- Show when hovering over points on optimization path
- Contour lines are bold when hovered, cost is shown
- Widget uses domain context handler, models etc.

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
