### PR TITLE
Interpolate gradient grid

### DIFF
--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -22,6 +22,8 @@ from Orange.preprocess.preprocess import Normalize
 from orangewidget.report import report
 from orangewidget.utils.widgetpreview import WidgetPreview
 
+from orangecontrib.educational.widgets.utils.gradient_grid import \
+    interpolate_grid
 from orangecontrib.educational.widgets.utils.linear_regression import \
     LinearRegression
 from orangecontrib.educational.widgets.utils.logistic_regression \
@@ -493,7 +495,8 @@ class OWGradientDescent(OWWidget):
         if self.cost_grid is None:
             return
 
-        bitmap = self.cost_grid * (255 / np.max(self.cost_grid))  # make a copy
+        cg = interpolate_grid(self.cost_grid, 256)
+        bitmap = cg * (255 / np.max(cg))  # make a copy
         bitmap = bitmap.astype(np.uint8)
 
         h, s, v = rgb_to_hsv(*self.default_background_color / 255)
@@ -518,7 +521,6 @@ class OWGradientDescent(OWWidget):
         contour = Contour(xv, yv, self.cost_grid)
         contour_lines = contour.contours(
             np.linspace(np.min(self.cost_grid), np.max(self.cost_grid), 20))
-
         for key, value in contour_lines.items():
             for line in value:
                 if len(line) > 3:

--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -533,7 +533,9 @@ class OWGradientDescent(OWWidget):
 
                 contour = pg.PlotCurveItem(
                     *np.array(list(interpol_line)).T,
-                    pen=self._contour_pen(False))
+                    pen=self._contour_pen(False),
+                    antialias=True
+                )
                 contour.value = key
                 self.graph.addItem(contour)
                 self.contours.append(contour)

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -30,6 +30,8 @@ from Orange.widgets.visualize.owscatterplotgraph import OWScatterPlotBase
 from Orange.widgets.visualize.utils.plotutils import SymbolItemSample
 from Orange.widgets.widget import Msg, Input, Output
 
+from orangecontrib.educational.widgets.utils.gradient_grid import \
+    interpolate_grid
 from orangecontrib.educational.widgets.utils.polynomialtransform \
     import PolynomialTransform
 from orangecontrib.educational.widgets.utils.contour import Contour
@@ -409,7 +411,7 @@ class OWPolynomialClassification(OWBaseLearner):
         if not self._treelike:
             self.probabilities_grid = self.blur_grid(self.probabilities_grid)
 
-        bitmap = self.probabilities_grid.copy()
+        bitmap = interpolate_grid(self.probabilities_grid, 256)
         bitmap *= 255
         bitmap = bitmap.astype(np.uint8)
 

--- a/orangecontrib/educational/widgets/utils/gradient_grid.py
+++ b/orangecontrib/educational/widgets/utils/gradient_grid.py
@@ -1,0 +1,27 @@
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
+
+def interpolate_grid(values, resolution):
+    """
+    Resize grid of values from its size to the shape resolution x resolution.
+    Use linear interpolation for points in between current points.
+
+    Parameters
+    ----------
+    values
+        Two-dimensional grid of values
+    resolution
+        Resolution of resulting grid
+
+    Returns
+    -------
+    The output grid with shape resolution x resolution
+    """
+    x = np.linspace(0, 1, values.shape[1])
+    y = np.linspace(0, 1, values.shape[0])
+    interpolator = RegularGridInterpolator((x, y), values)
+
+    points = np.linspace(0, 1, resolution)
+    xv, yv = np.meshgrid(points, points)
+    return interpolator((yv, xv))


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
After the replacing HighCharts with PyQtGraph background gradients are not smooth. 

##### Description of changes
- This PR smooths gradients of Gradient Descent and Polynomial Classification widget
- Turns antialiasing on for Gradient descent contours to smoothen them

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
