### PR TITLE
Documentation: enable building with html builder

### DIFF
--- a/orangecontrib/educational/widgets/__init__.py
+++ b/orangecontrib/educational/widgets/__init__.py
@@ -15,7 +15,7 @@ WIDGET_HELP_PATH = (
     # You still need to build help pages using
     # make htmlhelp
     # inside doc folder
-    ("{DEVELOP_ROOT}/doc/_build/htmlhelp/index.html", None),
+    ("{DEVELOP_ROOT}/doc/_build/html/index.html", None),
 
     # Documentation included in wheel
     # Correct DATA_FILES entry is needed in setup.py and documentation has to be built

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ def include_documentation(local_dir, install_dir):
 
 
 if __name__ == '__main__':
-    include_documentation('doc/_build/htmlhelp', 'help/orange3-educational')
+    include_documentation('doc/_build/html', 'help/orange3-educational')
     setup(
         name=NAME,
         version=VERSION,


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
In https://github.com/biolab/orange3-educational/pull/109 we changed the documentation theme to shpinx rtd theme. It was found out that it does not support htmlhelp builder. 

##### Description of changes
Since with this theme, it is not required to build the documentation with htmlhelp I am changing the setting such that they are compatible with html builder. From now on we build documentation with `make html` instead of `make htmlhelp`


##### Includes
- [ ] Code changes
- [ ] Tests
- [X] Documentation
