### PR TITLE
KMeans: Fix problem with adding centroids

### DIFF
--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -133,8 +133,8 @@ class KMeansPlotWidget(pg.PlotWidget):
             return
 
         ev.accept()
-        self.moved = True
         if self.centroid_index is not None:
+            self.moved = True
             pos = self.plotItem.mapToView(QPointF(ev.pos()))
             self.centroid_dragged.emit(self.centroid_index, pos.x(), pos.y())
 


### PR DESCRIPTION
##### Issue

Centroids were sometimes not added on-click.

##### Description of changes

If the user moved the mouse while clicking on empty space, the plot recorded this as dragging and didn't add a centroid.

While this certainly did happen, I don't know whether that's the only problem or there's something else as well. I can't reproduce the problem any longer, anyway.

##### Includes
- [X] Code changes
