### PR TITLE
Replace np.float with float

### DIFF
--- a/orangecontrib/educational/widgets/utils/gradient_descent.py
+++ b/orangecontrib/educational/widgets/utils/gradient_descent.py
@@ -112,7 +112,7 @@ class GradientDescent:
         # calculates gradient and modify theta
         grad = self.dj(self.theta, self.stochastic)
         if self.stochastic:
-            self.theta -= np.sum(np.float64(self.alpha) * grad, axis=0)
+            self.theta -= np.sum(float(self.alpha) * grad, axis=0)
         else:
             self.theta -= self.alpha * grad
 

--- a/orangecontrib/educational/widgets/utils/tests/test_linear_regression.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_linear_regression.py
@@ -320,7 +320,7 @@ class TestLinearRegression(unittest.TestCase):
 
         theta = np.ones(len(self.housing.domain.attributes))
         # test with one theta and with list of thetas
-        self.assertEqual(type(lr.j(theta)), np.float64)
+        self.assertEqual(type(lr.j(theta)), float)
         self.assertEqual(
             len(lr.j(np.vstack((theta, theta * 2)))), 2)
 

--- a/orangecontrib/educational/widgets/utils/tests/test_logistic_regression.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_logistic_regression.py
@@ -197,7 +197,7 @@ class TestLogisticRegression(unittest.TestCase):
         lr.set_data(self.iris)
 
         # test with one theta and with list of thetas
-        self.assertEqual(type(lr.j(np.array([1., 1., 1., 1.]))), np.float64)
+        self.assertEqual(type(lr.j(np.array([1., 1., 1., 1.]))), float)
         self.assertEqual(
             len(lr.j(np.array([[1., 1., 1., 1.], [2, 2, 2, 2]]))), 2)
 
@@ -249,7 +249,7 @@ class TestLogisticRegression(unittest.TestCase):
         lr = self.logistic_regression
 
         # test length
-        self.assertEqual(type(lr.g(1)), np.float64)
+        self.assertEqual(type(lr.g(1)), float)
         self.assertEqual(len(lr.g(np.array([1, 1]))), 2)
         self.assertEqual(len(lr.g(np.array([1, 1, 1]))), 3)
         self.assertEqual(len(lr.g(np.array([1, 1, 1, 1]))), 4)


### PR DESCRIPTION
Like in core Orange, the deprecated `np.float` must be replaced with `float`.

##### Includes
- [X] Code changes
