### PR TITLE
Fixes for table locking

### DIFF
--- a/orangecontrib/educational/tests/__init__.py
+++ b/orangecontrib/educational/tests/__init__.py
@@ -1,2 +1,0 @@
-import Orange
-Orange.data.Table.LOCKING = False

--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -411,7 +411,7 @@ class OWKmeans(OWWidget):
         km = self.k_means
         k = km.k
         if cx is None:
-            cx, cy = km.centroids.T
+            cx, cy = km.centroids.copy().T
         self.centroids_item.setData(
             cx, cy,
             pen=self.centr_pens[:k], brush=self.brushes[:k])
@@ -438,7 +438,7 @@ class OWKmeans(OWWidget):
             self.update_membership_lines(*pos.T)
 
         start = np.array(self.centroids_item.getData()).T
-        final = self.k_means.centroids
+        final = self.k_means.centroids.copy()
         self._animate(start, final, update, update)
 
     def animate_membership(self):
@@ -607,13 +607,14 @@ class OWKmeans(OWWidget):
             classes = [clust_var]
             domain = Domain(attributes, classes, meta_attrs)
             annotated_data = Table.from_table(domain, self.data)
-            annotated_data.Y[self.selected_rows] = km.clusters
+            with annotated_data.unlocked(annotated_data.Y):
+                annotated_data.Y[self.selected_rows] = km.clusters
 
             if self.attr_x is self.attr_y:
                 attrs = [self.attr_x.renamed(name) for name in "xy"]
             else:
                 attrs = [self.attr_x, self.attr_y]
-            centroids = Table.from_numpy(Domain(attrs), km.centroids)
+            centroids = Table.from_numpy(Domain(attrs), km.centroids.copy())
             self.Outputs.annotated_data.send(annotated_data)
             self.Outputs.centroids.send(centroids)
 

--- a/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
+++ b/orangecontrib/educational/widgets/tests/test_owgradientdescent.py
@@ -910,8 +910,12 @@ class TestOWGradientDescent(WidgetTest):
         w = self.widget
 
         def send_sparse_data(data):
-            data.X = sp.csr_matrix(data.X)
-            data.Y = sp.csr_matrix(data.Y)
+            Y = data.Y
+            if Y.ndim == 1:
+                Y = np.atleast_2d(data.Y).T
+            data = data.from_numpy(data.domain,
+                                   sp.csr_matrix(data.X),
+                                   sp.csr_matrix(Y))
             self.send_signal(w.Inputs.data, data)
 
         # one class variable

--- a/orangecontrib/educational/widgets/tests/test_owkmeans.py
+++ b/orangecontrib/educational/widgets/tests/test_owkmeans.py
@@ -170,15 +170,17 @@ class TestOWKmeans(WidgetTest):
         self.assertTrue(self.widget.Error.num_features.is_shown())
 
     def test_data_no_non_nan_data(self):
-        self.dataxy[:5, 0] = np.nan
-        self.dataxy[5:, 1] = np.nan
+        with self.dataxy.unlocked():
+            self.dataxy[:5, 0] = np.nan
+            self.dataxy[5:, 1] = np.nan
         self.send_signal(self.widget.Inputs.data, self.dataxy)
         self.assertIsNone(self.widget.reduced_data)
         self.assertIsNone(self.widget.k_means)
         self.assertTrue(self.widget.Error.no_nonnan_data.is_shown())
 
     def test_data_some_nan_data(self):
-        self.dataxy[:5, 0] = np.nan
+        with self.dataxy.unlocked():
+            self.dataxy[:5, 0] = np.nan
         self.send_signal(self.widget.Inputs.data, self.dataxy)
         np.testing.assert_equal(self.widget.reduced_data, self.dataxy.X[5:])
 

--- a/orangecontrib/educational/widgets/tests/test_owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/tests/test_owpolynomialclassification.py
@@ -266,8 +266,12 @@ class TestOWPolynomialClassificationNoGrid(WidgetTest):
         w = self.widget
 
         def send_sparse_data(data):
-            data.X = sp.csr_matrix(data.X)
-            data.Y = sp.csr_matrix(data.Y)
+            Y = data.Y
+            if Y.ndim == 1:
+                Y = np.atleast_2d(data.Y).T
+            data = data.from_numpy(data.domain,
+                                   sp.csr_matrix(data.X),
+                                   sp.csr_matrix(Y))
             self.send_signal(w.Inputs.data, data)
 
         # one class variable
@@ -283,8 +287,9 @@ class TestOWPolynomialClassificationNoGrid(WidgetTest):
 
     def test_non_in_data(self):
         w = self.widget
-        self.iris.Y[:10] = np.nan
-        self.iris.X[-4:, 0] = np.nan
+        with self.iris.unlocked():
+            self.iris.Y[:10] = np.nan
+            self.iris.X[-4:, 0] = np.nan
 
         self.send_signal(w.Inputs.data, self.iris)
         np.testing.assert_equal(w.selected_data.X, self.iris.X[:-4, :2])

--- a/orangecontrib/educational/widgets/tests/test_owpolynomialregression.py
+++ b/orangecontrib/educational/widgets/tests/test_owpolynomialregression.py
@@ -237,7 +237,7 @@ class TestOWPolynomialRegression(WidgetTest):
         When some rows are nan in attributes array widget crashes.
         GH-43
         """
-        data = self.data[::50]
+        data = self.data[::50].copy()
         with data.unlocked(data.X):
             data.X[0] = np.nan
         self.send_signal(self.widget.Inputs.data, data)

--- a/orangecontrib/educational/widgets/tests/test_owpolynomialregression.py
+++ b/orangecontrib/educational/widgets/tests/test_owpolynomialregression.py
@@ -238,7 +238,8 @@ class TestOWPolynomialRegression(WidgetTest):
         GH-43
         """
         data = self.data[::50]
-        data.X[0] = np.nan
+        with data.unlocked(data.X):
+            data.X[0] = np.nan
         self.send_signal(self.widget.Inputs.data, data)
 
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ DATA_FILES = [
 ]
 
 INSTALL_REQUIRES = [
-    'Orange3 >=3.31',
+    'Orange3 >=3.31.1',
     'BeautifulSoup4',
     'numpy',
 ]

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ DATA_FILES = [
 ]
 
 INSTALL_REQUIRES = [
-    'Orange3 >=3.27.1',
+    'Orange3 >=3.31',
     'BeautifulSoup4',
     'numpy',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,8 @@ setenv =
 deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
-    oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.31
+    oldest: scikit-learn~=1.0.1
+    oldest: orange3==3.31.1
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ deps =
     pyqt5==5.12.*
     pyqtwebengine==5.12.*
     oldest: scikit-learn~=0.22.0
-    oldest: orange3==3.27.1
+    oldest: orange3==3.31
     latest: git+git://github.com/biolab/orange3.git#egg=orange3
     latest: git+git://github.com/biolab/orange-canvas-core.git#egg=orange-canvas-core
     latest: git+git://github.com/biolab/orange-widget-base.git#egg=orange-widget-base


### PR DESCRIPTION
##### Issue

Orange now locks tables (in tests), thus the tests (and code) need to be fixed or locking disabled; preferrably the former.

Requires Orange3.31 with support for table locking.

##### Description of changes

Tests are fixed.

The code for k-means contained an actual bug: the output table included an array, which was subsequently changed by the module used in the widget.

##### Includes
- [X] Code changes
- [X] Tests
