### PR TITLE
Disable table locking until Orange 3.31

### DIFF
--- a/orangecontrib/educational/tests/__init__.py
+++ b/orangecontrib/educational/tests/__init__.py
@@ -1,0 +1,2 @@
+import Orange
+Orange.data.Table.LOCKING = False


### PR DESCRIPTION
##### Issue

Until https://github.com/biolab/orange3/pull/5381 is released, add-ons can neither support unlocking (because released versions do not support it) nor pass the test (because latest version requires unlocking). Thus add-ons will have to disable locking at first, and use unlocking when available-

##### Description of changes

Disable `Table.LOCKING`.

##### Includes
- [X] Code changes
- [X] Tests
