### PR TITLE
Polynomial Classification: Show original class

### DIFF
--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -270,7 +270,7 @@ class OWPolynomialClassification(OWBaseLearner):
                     np.isfinite(self.selected_data.X),
                     axis=1)
             )
-        if not valid_data.size:
+        if not np.any(np.isfinite(self.data.Y[valid_data])):
             self.Error.no_nonnan_data()
             self.selected_data = None
             self.orig_class = None
@@ -296,7 +296,8 @@ class OWPolynomialClassification(OWBaseLearner):
         self.probabilities_grid = None
         if self.selected_data is not None and self.learner is not None:
             try:
-                self.model = self.learner(self.selected_data)
+                defined = self.selected_data[np.isfinite(self.selected_data.Y)]
+                self.model = self.learner(defined)
                 self.model.name = self.learner_name
             except Exception as e:
                 self.Error.fitting_failed(str(e))

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -343,7 +343,7 @@ class OWPolynomialClassification(OWBaseLearner):
 
     def help_event(self, event):
         if self.probabilities_grid is None:
-            return
+            return False
 
         pos = event.scenePos()
         pos = self.graph.plot_widget.mapToView(pos)


### PR DESCRIPTION
##### Issue

Resolves #134.

##### Description of changes

At one point (presumably #112) somebody (presumanbly I) decided to expose that polynomial classifier classifies the target class vs. others by showing other classes as gray. At some point in one lecture, this started bothering me - I wanted to see both, actual and predicted classes. 

This PR thus backtracks somewhat. At the same time it allows for observing/comparing the actual classes and predictions by showing the actual class with pen and the prediction with brush (with transparency corresponding to probability).

The background still shows the target color vs. gray to emphasize that the model predicts the target (e.g. the two classes are not symmetric - yes, mathematically, but not when we discuss it in class).

When predicting a binary class, the brush of the other class matches its color. When predicting multiple classes, the brush for others is gray. See the two images below.

<img width="532" alt="Screenshot 2022-02-05 at 17 01 49" src="https://user-images.githubusercontent.com/2387315/152649396-69211079-e8c8-48e6-ae21-7bec443ced1e.png">

<img width="533" alt="Screenshot 2022-02-05 at 17 03 21" src="https://user-images.githubusercontent.com/2387315/152649401-38baa751-26b0-4293-976a-ef921019141a.png">

##### Includes
- [X] Code changes
- [ ] Tests
