### PR TITLE
[FIX] Fix minor bugs in Polynomial Classification

### DIFF
--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -341,7 +341,7 @@ class OWPolynomialClassification(OWBaseLearner):
 
     def help_event(self, event):
         if self.probabilities_grid is None:
-            return
+            return False
 
         pos = event.scenePos()
         pos = self.graph.plot_widget.mapToView(pos)

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -206,7 +206,8 @@ class OWPolynomialClassification(OWBaseLearner):
             return
 
         self.data = data
-        non_empty = np.bincount(data.Y[np.isfinite(data.Y)].astype(int)) > 0
+        non_empty = np.bincount(data.Y[np.isfinite(data.Y)].astype(int),
+                                minlength=len(domain.class_var.values)) > 0
         values = np.array(domain.class_var.values)[non_empty]
         combo.addItems(values.tolist())
         self.var_model.set_domain(self.data.domain)


### PR DESCRIPTION
##### Issue

- When fitting failed, hovering produced error because the helper returned `None` instead of `False`.
- When there where no instances in the last class, the widget failed because the number of bins returned by bincount to determine non-empty classes did not match the number of classes.

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
