### PR TITLE
setup.py - add missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,13 @@ DATA_FILES = [
 ]
 
 INSTALL_REQUIRES = [
-    'Orange3 >=3.31.1',
+    'anyqt',
     'BeautifulSoup4',
     'numpy',
+    'Orange3 >=3.31.1',
+    'orange-widget-base',
+    'scikit-learn',
+    'pyqtgraph',
 ]
 
 EXTRAS_REQUIRE = {


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description if the issue does not exist. -->
Some dependencies are used in the package but are not in setu.py. Since they come with Orange already, nobody considered adding them.

##### Description of changes
Add them to setup.py

##### Includes
- [ ] Code changes
- [ ] Tests
- [ ] Documentation
