### PR TITLE
[ENH] Polynomial regression - warn about huge values

### DIFF
--- a/orangecontrib/educational/widgets/tests/test_owpolynomialregression.py
+++ b/orangecontrib/educational/widgets/tests/test_owpolynomialregression.py
@@ -346,6 +346,18 @@ class TestOWPolynomialRegression(WidgetTest):
         # I haven't computed these values manually, I just copied them
         np.testing.assert_almost_equal(coef.X.T, [[ 3.1052632, -0.2631579]])
 
+    def test_large_polynomial_values(self):
+        x, y = (ContinuousVariable(n) for n in "xy")
+        data = Table.from_numpy(Domain([x], y), [[1], [30]], [3, 5])
+        self.send_signal(self.widget.Inputs.data, data)
+
+        self.widget.controls.polynomialexpansion.setValue(9)
+        self.assertFalse(self.widget.Warning.large_diffs.is_shown())
+        self.widget.controls.polynomialexpansion.setValue(10)
+        self.assertTrue(self.widget.Warning.large_diffs.is_shown())
+        self.widget.controls.polynomialexpansion.setValue(9)
+        self.assertFalse(self.widget.Warning.large_diffs.is_shown())
+
 
 class PolynomialFeaturesTest(unittest.TestCase):
     def test_1d(self):


### PR DESCRIPTION
##### Issue
Polynomial features can become huge due to the exponentiation of numbers. Huge numbers (and number differences) can cause model algorithms to be numerically unstable. For example, a higher degree of polynomial features should result in a better fit to the curve, but when numbers are high and linear regression weight becomes really small, it is not the case anymore (because of numeric instability):

![Screenshot 2023-04-03 at 11 09 38](https://user-images.githubusercontent.com/6421558/229465959-defb7426-e76f-4781-b7cc-6e5c5e23d31e.png)

##### Description of changes
It can be fixed with normalization, but as discussed with Tomaz, it is better just to warn since it is an educational add-on, and we do not want to do any values changing in the background (which would also affect the model weights).

##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
