### PR TITLE
Fix failing tests

### DIFF
--- a/orangecontrib/educational/widgets/ow1ka.py
+++ b/orangecontrib/educational/widgets/ow1ka.py
@@ -20,20 +20,7 @@ from Orange.widgets import widget, gui, settings
 from Orange.data import Table
 from Orange.widgets.utils.signals import Output
 from Orange.widgets.utils.webview import WebviewWidget
-try:
-    from Orange.widgets.utils.webview import wait
-except ImportError:  # WebKit and before wait() was toplevel
-    import time
-    from AnyQt.QtWidgets import qApp
-    from AnyQt.QtCore import QEventLoop
-
-    def wait(until: callable, timeout=5000):
-        started = time.perf_counter()
-        while not until():
-            qApp.processEvents(QEventLoop.ExcludeUserInputEvents)
-            if (time.perf_counter() - started) * 1000 > timeout:
-                raise TimeoutError()
-
+from orangewidget.utils.webview import wait
 
 log = logging.getLogger(__name__)
 
@@ -353,8 +340,7 @@ class OW1ka(widget.OWWidget):
 
 
 if __name__ == "__main__":
-    a = QApplication([])
-    ow = OW1ka()
-    ow.combo.setEditText('https://www.1ka.si/podatki/139234/A4228E24/')
-    ow.show()
-    a.exec_()
+    from orangewidget.utils.widgetpreview import WidgetPreview
+
+    # use link: https://www.1ka.si/podatki/139234/A4228E24/
+    widget_preview = WidgetPreview(OW1ka).run()

--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -307,12 +307,12 @@ class OWGradientDescent(OWWidget):
                      self.restart_button, self.properties_box, self.options_box]:
             item.setDisabled(disabled)
 
-    key_actions = {(0, Qt.Key_Space): step}  # space button for step
+    key_actions = {(Qt.NoModifier, Qt.Key_Space): step}  # space button for step
 
     def keyPressEvent(self, e):
         """Bind 'back' key to step back"""
-        if (int(e.modifiers()), e.key()) in self.key_actions:
-            fun = self.key_actions[(int(e.modifiers()), e.key())]
+        if (e.modifiers(), e.key()) in self.key_actions:
+            fun = self.key_actions[(e.modifiers(), e.key())]
             fun(self)
         else:
             super().keyPressEvent(e)

--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -613,8 +613,7 @@ class OWKmeans(OWWidget):
         Return None if there are no non-nan columns
         """
         attrs = [self.attr_x, self.attr_y]
-        x = np.vstack(tuple(self.data.get_column_view(attr)[0]
-                            for attr in attrs)).T
+        x = np.vstack(tuple(self.data.get_column(attr) for attr in attrs)).T
         not_nan = ~np.isnan(x).any(axis=1)
         x = x[not_nan]  # remove rows with nan
         if not x.size:

--- a/orangecontrib/educational/widgets/utils/polynomialtransform.py
+++ b/orangecontrib/educational/widgets/utils/polynomialtransform.py
@@ -82,7 +82,7 @@ class TransformationMultipleVariables:
             elif inst:
                 data_col = np.array([float(data[attr_index])])
             else:
-                data_col = data.get_column_view(attr_index)[0]
+                data_col = data.get_column(attr_index)
             data_all.append(data_col)
         transformed_col = self.transform(data_all)
         if (inst and isinstance(transformed_col, np.ndarray) and

--- a/orangecontrib/educational/widgets/utils/tests/test_polynomialtransform.py
+++ b/orangecontrib/educational/widgets/utils/tests/test_polynomialtransform.py
@@ -43,30 +43,31 @@ class TestPolynomialTransform(unittest.TestCase):
         transformed_data = polynomial_transform(self.data)
 
         for i, row in enumerate(transformed_data):
-            self.assertEqual(row[0], self.data[i][0])
-            self.assertEqual(row[1], self.data[i][1])
+            self.assertAlmostEqual(row[0], self.data[i][0])
+            self.assertAlmostEqual(row[1], self.data[i][1])
 
-            self.assertEqual(row[2], self.data[i][0] ** 2)
-            self.assertEqual(row[3], self.data[i][0] * self.data[i][1])
-            self.assertEqual(row[4], self.data[i][1] ** 2)
+            self.assertAlmostEqual(row[2], self.data[i][0] ** 2)
+            self.assertAlmostEqual(row[3], self.data[i][0] * self.data[i][1])
+            self.assertAlmostEqual(row[4], self.data[i][1] ** 2)
 
-            self.assertEqual(row[5], self.data[i][0] ** 3)
-            self.assertEqual(row[6], self.data[i][0] ** 2 * self.data[i][1])
-            self.assertEqual(row[7], self.data[i][0] * self.data[i][1] ** 2)
-            self.assertEqual(row[8], self.data[i][1] ** 3)
+            self.assertAlmostEqual(row[5], self.data[i][0] ** 3)
+            self.assertAlmostEqual(row[6], self.data[i][0] ** 2 * self.data[i][1])
+            self.assertAlmostEqual(row[7], self.data[i][0] * self.data[i][1] ** 2)
+            self.assertAlmostEqual(row[8], self.data[i][1] ** 3)
 
-            self.assertEqual(row[9], self.data[i][0] ** 4)
-            self.assertEqual(row[10], self.data[i][0] ** 3 * self.data[i][1])
-            self.assertEqual(
-                row[11], self.data[i][0] ** 2 * self.data[i][1] ** 2)
-            self.assertEqual(row[12], self.data[i][0] * self.data[i][1] ** 3)
-            self.assertEqual(row[13], self.data[i][1] ** 4)
+            self.assertAlmostEqual(row[9], self.data[i][0] ** 4)
+            self.assertAlmostEqual(row[10], self.data[i][0] ** 3 * self.data[i][1])
+            self.assertAlmostEqual(row[11], self.data[i][0] ** 2 * self.data[i][1] ** 2)
+            self.assertAlmostEqual(row[12], self.data[i][0] * self.data[i][1] ** 3)
+            self.assertAlmostEqual(row[13], self.data[i][1] ** 4)
 
-            self.assertEqual(row[14], self.data[i][0] ** 5)
-            self.assertEqual(row[15], self.data[i][0] ** 4 * self.data[i][1])
-            self.assertEqual(
-                row[16], self.data[i][0] ** 3 * self.data[i][1] ** 2)
-            self.assertEqual(
-                row[17], self.data[i][0] ** 2 * self.data[i][1] ** 3)
-            self.assertEqual(row[18], self.data[i][0] * self.data[i][1] ** 4)
-            self.assertEqual(row[19], self.data[i][1] ** 5)
+            self.assertAlmostEqual(row[14], self.data[i][0] ** 5)
+            self.assertAlmostEqual(row[15], self.data[i][0] ** 4 * self.data[i][1])
+            self.assertAlmostEqual(row[16], self.data[i][0] ** 3 * self.data[i][1] ** 2)
+            self.assertAlmostEqual(row[17], self.data[i][0] ** 2 * self.data[i][1] ** 3)
+            self.assertAlmostEqual(row[18], self.data[i][0] * self.data[i][1] ** 4)
+            self.assertAlmostEqual(row[19], self.data[i][1] ** 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
##### Issues and Changes

- Widgets are not PyQt6 compatible - fix PyQt compatibility
- Some widgets still use `get_column_view` - use `get_column` instead
- One test start to fail due to the difference in the 16th decimal number - use `assertAlmostEqual` instead of `assertEqual`


##### Includes
- [X] Code changes
- [X] Tests
- [ ] Documentation
