### PR TITLE
Annotate graph_name with graph's types

### DIFF
--- a/orangecontrib/educational/widgets/owgradientdescent.py
+++ b/orangecontrib/educational/widgets/owgradientdescent.py
@@ -92,7 +92,7 @@ class OWGradientDescent(OWWidget):
         model = Output("Model", Model)
         coefficients = Output("Coefficients", Table)
 
-    graph_name = "grapH"
+    graph_name = "graph"  # QGraphicsView (pg.PlotWidget)
 
     settingsHandler = settings.DomainContextHandler(
         match_values=settings.DomainContextHandler.MATCH_VALUES_CLASS)
@@ -455,7 +455,7 @@ class OWGradientDescent(OWWidget):
         if self.stochastic:
             caption_items += (("Stochastic step size", self.step_size),)
         caption = report.render_items_vert(caption_items)
-        self.report_plot(self.graph)
+        self.report_plot()
         self.report_caption(caption)
 
     ##############################

--- a/orangecontrib/educational/widgets/owkmeans.py
+++ b/orangecontrib/educational/widgets/owkmeans.py
@@ -180,7 +180,7 @@ class OWKmeans(OWWidget):
     attr_y = settings.ContextSetting(None)
     sound_effects = settings.Setting(False)
 
-    graph_name = 'scatter'
+    graph_name = 'plot'  # pg.GraphicsItem  (pg.PlotItem)
     move_sound = regroup_sound = None
 
     step_trigger = Signal()
@@ -659,7 +659,7 @@ class OWKmeans(OWWidget):
     def send_report(self):
         if self.data is None:
             return
-        self.report_plot(self.plot)
+        self.report_plot()
 
 
 if __name__ == "__main__":

--- a/orangecontrib/educational/widgets/owpiecharts.py
+++ b/orangecontrib/educational/widgets/owpiecharts.py
@@ -35,7 +35,7 @@ class OWPieChart(widget.OWWidget):
     attribute = ContextSetting(None)
     split_var = ContextSetting(None)
     explode = Setting(False)
-    graph_name = "scene"
+    graph_name = "scene"  # QGraphicsScene
 
     def __init__(self):
         super().__init__()

--- a/orangecontrib/educational/widgets/owpolynomialclassification.py
+++ b/orangecontrib/educational/widgets/owpolynomialclassification.py
@@ -98,7 +98,7 @@ class OWPolynomialClassification(OWBaseLearner):
     degree = Setting(1)
     contours_enabled = Setting(True)
 
-    graph_name = 'graph'
+    graph_name = 'graph.plot_widget'  # QGraphicsView (pg.PlotWidget)
 
     class Error(OWBaseLearner.Error):
         num_features = Msg("Data must contain at least two numeric variables.")
@@ -278,7 +278,6 @@ class OWPolynomialClassification(OWBaseLearner):
         else:
             self.selected_data = self.selected_data[valid_data]
             self.orig_class = self.data.Y[valid_data]
-
 
     def apply(self):
         self.update_model()
@@ -544,7 +543,7 @@ class OWPolynomialClassification(OWBaseLearner):
             return
         name = "" if self.degree == 1 \
             else f"Model with polynomial expansion {self.degree}"
-        self.report_plot(name=name, plot=self.graph.plot_widget)
+        self.report_plot(name=name)
 
 
 if __name__ == "__main__":

--- a/orangecontrib/educational/widgets/owpolynomialregression.py
+++ b/orangecontrib/educational/widgets/owpolynomialregression.py
@@ -190,7 +190,7 @@ class OWPolynomialRegression(OWBaseLearner):
     regressor_name = ""
 
     want_main_area = True
-    graph_name = 'plot'
+    graph_name = 'plot'  # pg.GraphicsItem  (pg.PlotItem)
 
     class Warning(OWBaseLearner.Warning):
         large_diffs = Msg(


### PR DESCRIPTION
##### Issue

We don't know which object types are passed to methods for reporting, saving charts and copying to clipboard.

##### Description of changes

- Added comments with one of the four types handled by `ImgFormat` (`pg.GraphicsItem`, `QGraphicsScene`, `QGraphicsView`, `QWidget`), and the actual derived type, if applicable.
- Fix `graph_name` for k-means.
- Polynomial classification and k-means passed the object to be plotted as an argument to `report_plot`. If `graph_name` is given, it's better to use if for `report_plot` to avoid ambiguity.
