### PR TITLE
Random data - Fix editor event

### DIFF
--- a/orangecontrib/educational/widgets/owrandomdata.py
+++ b/orangecontrib/educational/widgets/owrandomdata.py
@@ -91,7 +91,7 @@ class ParametersEditor(QGroupBox):
         self.trash_button.setHidden(False)
 
     def leaveEvent(self, e):
-        super().enterEvent(e)
+        super().leaveEvent(e)
         self.trash_button.setHidden(True)
 
     def add_standard_parameters(self, parent):


### PR DESCRIPTION
##### Issue
<!-- E.g. Fixes #1, Implements #2, etc. -->
<!-- Or a short description, if the issue does not exist. -->
Random data fail on PyQt6 because of wrong super call in leaveEvent

##### Description of changes
Call correct super

##### Includes
- [X] Code changes
- [ ] Tests
- [ ] Documentation
